### PR TITLE
refactoring of returnn jobs

### DIFF
--- a/returnn/extract_prior.py
+++ b/returnn/extract_prior.py
@@ -11,14 +11,25 @@ Path = setup_path(__package__)
 
 
 class ExtractPriorFromHDF5Job(Job):
-    def __init__(self, returnn_model, layer="output", plot_prior=False):
-        self.returnn_model = returnn_model
+    """
+    Extracts the prior information from a RETURNN generated HDF file,
+    and saves it in the RASR compatible .xml format
+    """
+
+    def __init__(self, prior_hdf_file, layer="output", plot_prior=False):
+        """
+
+        :param Path prior_hdf_file:
+        :param str layer:
+        :param bool plot_prior:
+        """
+        self.returnn_model = prior_hdf_file
         self.layer = layer
         self.plot_prior = plot_prior
 
-        self.prior = self.output_path("prior.xml", cached=True)
+        self.out_prior = self.output_path("prior.xml", cached=True)
         if self.plot_prior:
-            self.prior_plot = self.output_path("prior.png")
+            self.out_prior_plot = self.output_path("prior.png")
 
     def tasks(self):
         yield Task("run", resume="run", mini_task=True)
@@ -29,7 +40,7 @@ class ExtractPriorFromHDF5Job(Job):
 
         priors_list = np.asarray(priors_set[:])
 
-        with open(self.prior.get_path(), "wt") as out:
+        with open(self.out_prior.get_path(), "wt") as out:
             out.write(
                 '<?xml version="1.0" encoding="UTF-8"?>\n<vector-f32 size="%d">\n'
                 % priors_list.shape[0]
@@ -46,4 +57,4 @@ class ExtractPriorFromHDF5Job(Job):
             plt.xlabel("emission idx")
             plt.ylabel("prior")
             plt.grid(True)
-            plt.savefig(self.prior_plot.get_path())
+            plt.savefig(self.out_prior_plot.get_path())

--- a/returnn/oggzip.py
+++ b/returnn/oggzip.py
@@ -11,6 +11,11 @@ Path = setup_path(__package__)
 
 
 class BlissToOggZipJob(Job):
+    """
+    This Job is a wrapper around the RETURNN tool bliss-to-ogg-zip.py.
+
+    """
+
     __sis_hash_exclude__ = {"no_conversion": False}
 
     def __init__(
@@ -33,8 +38,8 @@ class BlissToOggZipJob(Job):
         :param int raw_sample_rate: raw audio sampling rate
         :param int feat_sample_rate: feature sampling rate
         :param bool no_conversion: do not call the actual conversion, assume the audio files are already correct
-        :param str|Path returnn_python_exe: path to python binary
-        :param str|Path returnn_root: path to root dir of RETURNN
+        :param Path|str returnn_python_exe: file path to the executable for running returnn (python binary or .sh)
+        :param Path|str returnn_root: file path to the RETURNN repository root folder
         """
         self.bliss_corpus = bliss_corpus
         self.segments = segments
@@ -52,7 +57,7 @@ class BlissToOggZipJob(Job):
             returnn_root if returnn_root is not None else gs.RETURNN_ROOT
         )
 
-        self.out = self.output_path("out.ogg.zip")
+        self.out_ogg_zip = self.output_path("out.ogg.zip")
 
     def tasks(self):
         yield Task("run", mini_task=True)
@@ -81,7 +86,7 @@ class BlissToOggZipJob(Job):
                 args.extend(["--feat_sample_rate", str(self.feat_sample_rate)])
 
         sp.check_call(args)
-        relink("out.ogg.zip", self.out.get_path())
+        relink("out.ogg.zip", self.out_ogg_zip.get_path())
 
     @classmethod
     def hash(cls, parsed_args):


### PR DESCRIPTION
- mainly docstrings and adding "out_" prefix
- create a util.create_executable instead of rnn.sh creation

I did not touch training and search yet, as this will come in a separate PR with more critical code changes.