### PR TITLE
rename filterbank keys

### DIFF
--- a/features/filterbank.py
+++ b/features/filterbank.py
@@ -20,7 +20,7 @@ def FilterbankJob(
     filterbank_options["samples_options"]["audio_format"] = crp.audio_format
     feature_flow = filterbank_flow(**filterbank_options)
 
-    port_name_mapping = {"features": "filterbank"}
+    port_name_mapping = {"features": "fb"}
 
     return FeatureExtractionJob(
         crp,

--- a/meta/system.py
+++ b/meta/system.py
@@ -241,8 +241,8 @@ class System:
             self.crp[corpus], **kwargs
         )
         f.add_alias("%s_fb_features" % corpus)
-        self.feature_caches[corpus]["filterbank"] = f.feature_path["filterbank"]
-        self.feature_bundles[corpus]["filterbank"] = f.feature_bundle["filterbank"]
+        self.feature_caches[corpus]["fb"] = f.feature_path["fb"]
+        self.feature_bundles[corpus]["fb"] = f.feature_bundle["fb"]
 
         feature_path = rasr.FlagDependentFlowAttribute(
             "cache_mode",


### PR DESCRIPTION
fixes erroneous keys and makes the keys more consistent with the other feature extraction jobs