### PR TITLE
Add VariableString class

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -13,6 +13,8 @@ import pprint
 import string
 import textwrap
 
+from recipe.i6_core.util import VariableString
+
 
 def instanciate_vars(o):
     """
@@ -22,7 +24,7 @@ def instanciate_vars(o):
     :param Any o: nested structure that may contain Variable objects
     :return:
     """
-    if isinstance(o, Variable):
+    if isinstance(o, Variable) or isinstance(o, VariableString):
         o = o.get()
     elif isinstance(o, list):
         for k in range(len(o)):


### PR DESCRIPTION
- helper to embed tk.Path and tk.Variable
  objects into formatted strings
- allows for correct (non-absolute) hashing

This is a draft again, because I want to first get everyones opinion on this approach, and also on the name of the class.

@mmz33 reported a problem when he wanted to add output paths from jobs to the ExternSprintDataset config parameters that are part of a RETURNNConfig dict. If you do e.g. `config['xyz'] = "--my-parameter %s" % tk.uncached_path(some_path)` the hashing will be based on the absolute path, and as such will change when you move the setup.

The syntax now would be: `config['xyz'] = VariableString("--my-parameter %s", [some_path])`