### PR TITLE
changed extra_python to python_epilog

### DIFF
--- a/adaptation/linear_adaptation_layer.py
+++ b/adaptation/linear_adaptation_layer.py
@@ -248,18 +248,6 @@ class MetaLinearAdaptationJob(Job):
         import string
         import textwrap
 
-        PYTHON_CODE = textwrap.dedent(
-            """\
-                      #!rnn.py
-
-                      ${REGULAR_CONFIG}
-
-                      locals().update(**config)
-
-                      ${EXTRA_PYTHON_CODE}
-                      """
-        )
-
         config = job.returnn_config
         config.update(job.returnn_post_config)
         config.update(import_models)
@@ -285,8 +273,9 @@ class MetaLinearAdaptationJob(Job):
 
         python_code = string.Template(job.PYTHON_CODE).substitute(
             {
+                "PROLOG": job.returnn_config.python_prolog,
                 "REGULAR_CONFIG": "\n".join(config_lines),
-                "EXTRA_PYTHON_CODE": job.returnn_config.extra_python_code,
+                "EPILOG": job.returnn_config.python_epilog,
             }
         )
         # with open(file_path, 'wt', encoding='utf-8') as f:

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -369,15 +369,15 @@ class ReturnnTrainingJob(Job):
     @classmethod
     def hash(cls, kwargs):
         returnn_config = kwargs["returnn_config"]
-        extra_python_hash = (
-            returnn_config.extra_python
-            if returnn_config.extra_python_hash is None
-            else returnn_config.extra_python_hash
+        python_epilog_hash = (
+            returnn_config.python_epilog
+            if returnn_config.python_epilog_hash is None
+            else returnn_config.python_epilog_hash
         )
 
         d = {
             "returnn_config": returnn_config.config,
-            "extra_python": extra_python_hash,
+            "python_epilog": python_epilog_hash,
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],
         }


### PR DESCRIPTION
1- Adjustment of `ReturnnConfig` attribute, respecting returnn implementation. 
2- Elimination of `PYTHON_CODE` in the `make_recog_config()` of the class `MetaLinearAdaptationJob` implemented in `adaptation/linear_adaptation_layer.py`. The function modifies `PYTHON_CODE` of its respective passed parameter `job` and do not use the local variable.