### PR TITLE
fix inconsistent RETURNN config hash

### DIFF
--- a/returnn/rasr_training.py
+++ b/returnn/rasr_training.py
@@ -274,18 +274,11 @@ class ReturnnRasrTrainingJob(ReturnnTrainingJob):
         kwargs["crp"] = dev_crp
         dev_config, dev_post_config = cls.create_config(**kwargs)
         returnn_config = kwargs["returnn_config"]
-        python_epilog_hash = (
-            returnn_config.python_epilog
-            if returnn_config.python_epilog_hash is None
-            else returnn_config.python_epilog_hash
-        )
-
         d = {
             "train_config": train_config,
             "dev_config": dev_config,
             "alignment_flow": flow,
-            "returnn_config": returnn_config.config,
-            "python_epilog": python_epilog_hash,
+            "returnn_config": returnn_config,
             "rasr_exe": train_crp.nn_trainer_exe,
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -162,7 +162,7 @@ class ReturnnSearchJob(Job):
     @classmethod
     def hash(cls, kwargs):
         d = {
-            "returnn_config": kwargs["returnn_config"].hash(),
+            "returnn_config": kwargs["returnn_config"],
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],
             "model_checkpoint": kwargs["model_checkpoint"],

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -372,16 +372,8 @@ class ReturnnTrainingJob(Job):
 
     @classmethod
     def hash(cls, kwargs):
-        returnn_config = kwargs["returnn_config"]
-        python_epilog_hash = (
-            returnn_config.python_epilog
-            if returnn_config.python_epilog_hash is None
-            else returnn_config.python_epilog_hash
-        )
-
         d = {
-            "returnn_config": returnn_config.config,
-            "python_epilog": python_epilog_hash,
+            "returnn_config": returnn_config,
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],
         }


### PR DESCRIPTION
The way the RETURNN config object is hashed varied with every job.

So I thought the most consistent solution would be to give the config an explicit `_sis_hash` function which calls the hash helper on a specified dict. Of course this will break (with exception for the ReturnnSearchJob) every hash. 