### PR TITLE
Returnn Compatible BPE Jobs

### DIFF
--- a/bpe/apply.py
+++ b/bpe/apply.py
@@ -15,12 +15,16 @@ import i6_core.util as util
 
 
 class ApplyBPEModelToLexiconJob(Job):
-    def __init__(self, bpe_code, lexicon_path, vocabulary_path=None, subword_nmt_repo=None):
+    def __init__(
+        self, bpe_code, lexicon_path, vocabulary_path=None, subword_nmt_repo=None
+    ):
         self.bpe_code = bpe_code
         self.lexicon_path = lexicon_path
         self.vocabulary_path = vocabulary_path
 
-        self.subword_nmt_repo = subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        self.subword_nmt_repo = (
+            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        )
 
         self.out_converted_lexicon = self.output_path("lexicon.xml.gz", cached=True)
 
@@ -109,7 +113,9 @@ class ApplyBPEToTextJob(Job):
         """
         self.text_file = text_file
         self.bpe_codes = bpe_codes
-        self.subword_nmt_repo = subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        self.subword_nmt_repo = (
+            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        )
         self.bpe_vocab = bpe_vocab
 
         self.out_bpe_text = self.output_path("words_to_bpe.txt")
@@ -132,5 +138,5 @@ class ApplyBPEToTextJob(Job):
         if self.bpe_vocab:
             cmd += ["--vocabulary", tk.uncached_path(self.bpe_vocab)]
 
-        util.create_executable('apply_bpe.sh', cmd)
+        util.create_executable("apply_bpe.sh", cmd)
         sp.run(cmd, check=True)

--- a/bpe/train.py
+++ b/bpe/train.py
@@ -76,8 +76,9 @@ class TrainBPEModelJob(Job):
 class ReturnnTrainBpeJob(Job):
     def __init__(self, text_file, bpe_size, subword_nmt_repo=None, unk_label="UNK"):
         """
-        Create Bpe codes and vocab files
-        NOTE: This uses Albert's subword-nmt fork which is compatible to RETURNN BytePairEncoding class
+        Create Bpe codes and vocab files compatible with RETURNN BytePairEncoding
+        Repository:
+            https://github.com/albertz/subword-nmt
 
         :param Path|str text_file: corpus text file
         :param int bpe_size: number of BPE merge operations

--- a/bpe/train.py
+++ b/bpe/train.py
@@ -28,7 +28,9 @@ class TrainBPEModelJob(Job):
         self.dict_input = dict_input
         self.total_symbols = total_symbols
 
-        self.subword_nmt_repo = subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        self.subword_nmt_repo = (
+            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        )
 
         self.code_file = self.output_path("code")
 
@@ -84,7 +86,9 @@ class ReturnnTrainBpeJob(Job):
         """
         self.text_file = text_file
         self.bpe_size = bpe_size
-        self.subword_nmt_repo = subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        self.subword_nmt_repo = (
+            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+        )
         self.unk_label = unk_label
 
         self.out_bpe_codes = self.output_path("bpe.codes")
@@ -101,7 +105,7 @@ class ReturnnTrainBpeJob(Job):
             str(self.bpe_size),
         ]
 
-        util.create_executable('create_bpe_codes.sh', bpe_codes_cmd)
+        util.create_executable("create_bpe_codes.sh", bpe_codes_cmd)
 
         with util.uopen(self.text_file, "rb") as f:
             p = sp.Popen(
@@ -129,7 +133,7 @@ class ReturnnTrainBpeJob(Job):
             self.out_bpe_vocab.get_path(),
         ]
 
-        util.create_executable('create_bpe_vocab.sh', bpe_vocab_cmd)
+        util.create_executable("create_bpe_vocab.sh", bpe_vocab_cmd)
         sp.run(bpe_vocab_cmd, check=True)
 
         with util.uopen(self.out_bpe_vocab) as f:

--- a/tools/git.py
+++ b/tools/git.py
@@ -27,7 +27,7 @@ class CloneGitRepositoryJob(Job):
         self.branch = branch
         self.commit = commit
 
-        self.repository = self.output_path(checkout_folder_name, True)
+        self.out_repository = self.output_path(checkout_folder_name, True)
 
     def tasks(self):
         yield Task("run", mini_task=True)
@@ -36,7 +36,7 @@ class CloneGitRepositoryJob(Job):
         args = ["git", "clone", self.url]
         if self.branch is not None:
             args.extend(["-b", self.branch])
-        repository_dir = self.repository.get_path()
+        repository_dir = self.out_repository.get_path()
         args += [repository_dir]
         logging.info("running command: %s" % " ".join(args))
         sp.run(args)


### PR DESCRIPTION
Add BPE train and apply jobs that uses @albertz subword-nmt fork. This is compatible with RETURNN. I already used these jobs to train attention models for example. Now in the future, we probably want to have one job that uses `sentencepieces` software.

@curufinwe Should I remove the old train and apply BPE jobs? I am not sure if they are used.