### PR TITLE
Added DynamicSplitSegmentFileJob;

### DIFF
--- a/corpus/segments.py
+++ b/corpus/segments.py
@@ -271,7 +271,7 @@ class DynamicSplitSegmentFileJob(Job):
 
     def __init__(self, segment_file, concurrent):
         """
-        :param tk.Union[tk.Path, str] segment_file: segment file
+        :param tk.Path|str segment_file: segment file
         :param tk.Delayed concurrent: number of splits
         """
         self.segment_file = segment_file

--- a/corpus/segments.py
+++ b/corpus/segments.py
@@ -265,8 +265,8 @@ class SplitSegmentFileJob(Job):
 class DynamicSplitSegmentFileJob(Job):
 
     """
-    This split the segments to concurrent many shares.
-    It is a variant to the existing SplitSegmentFileJob, which requires a delayed variable for argument concurrent.
+    Split the segments to concurrent many shares. It is a variant to the existing SplitSegmentFileJob.
+    This requires a tk.Delayed variable (instead of int) for the argument concurrent.
     """
 
     def __init__(self, segment_file, concurrent):
@@ -282,7 +282,7 @@ class DynamicSplitSegmentFileJob(Job):
         yield Task("run", resume="run", mini_task=True)
 
     def run(self):
-        with uopen(tk.uncached_path(self.segment_file), "rt") as f:
+        with uopen(self.segment_file, "rt") as f:
             lines = [l for l in f.readlines() if len(l.strip()) > 0]
 
         nb_seg = len(lines)

--- a/corpus/segments.py
+++ b/corpus/segments.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from i6_core.util import MultiOutputPath
 from i6_core.lib import corpus
-from i6_core.util import chunks
+from i6_core.util import chunks, uopen
 
 from sisyphus import *
 
@@ -269,7 +269,7 @@ class DynamicSplitSegmentFileJob(Job):
     It is a variant to the existing SplitSegmentFileJob, which requires a delayed variable for argument concurrent.
     """
 
-    def __init__(self, segment_file: tk.Union[tk.Path, str], concurrent: tk.Delayed):
+    def __init__(self, segment_file, concurrent):
         """
         :param tk.Union[tk.Path, str] segment_file: segment file
         :param tk.Delayed concurrent: number of splits
@@ -282,12 +282,11 @@ class DynamicSplitSegmentFileJob(Job):
         yield Task("run", resume="run", mini_task=True)
 
     def run(self):
-        with open(tk.uncached_path(self.segment_file), "rt") as f:
+        with uopen(tk.uncached_path(self.segment_file), "rt") as f:
             lines = [l for l in f.readlines() if len(l.strip()) > 0]
 
         nb_seg = len(lines)
-        if isinstance(self.concurrent, tk.Delayed):
-            self.concurrent = self.concurrent.get()
+        self.concurrent = self.concurrent.get()
         seg_per_split = nb_seg // self.concurrent
         nb_rest_seg = nb_seg % self.concurrent
         end = 0

--- a/corpus/segments.py
+++ b/corpus/segments.py
@@ -292,7 +292,7 @@ class DynamicSplitSegmentFileJob(Job):
         end = 0
         for i in range(1, self.concurrent + 1):
             start = end
-            fpath = '{}/segments.{}'.format(self.out_split_dir, i)
+            fpath = "{}/segments.{}".format(self.out_split_dir, i)
             end += seg_per_split + (1 if i <= nb_rest_seg else 0)
             with open(fpath, "wt") as f:
                 f.writelines(lines[start:end])


### PR DESCRIPTION
Added DynamicSplitSegmentFileJob (see SplitSegmentFileJob) to avoid output paths conflicts with earlier settings. 
DynamicSplitSegmentFileJob receives a **Delayed** object for argument concurrent. 
Only an output directory called **out_split_dir** should be accessible after job creation.