### PR TITLE
Adds the output_mode to the hash of the ReturnnSearchJob

### DIFF
--- a/returnn/search.py
+++ b/returnn/search.py
@@ -171,6 +171,7 @@ class ReturnnSearchJob(Job):
             "returnn_root": kwargs["returnn_root"],
             "model_checkpoint": kwargs["model_checkpoint"],
             "search_data": kwargs["search_data"],
+            "output_mode": kwargs["output_mode"],
         }
         return super().hash(d)
 


### PR DESCRIPTION
The output_mode in the ReturnnSearchJob currently does not affect the hash.

This changes the hash. Is this still okay or should I add a `__sis_hash_exclude__`?
