### PR TITLE
Use create_returnn_config to get the hash in the ReturnnSearchJob and ReturnnTrainingJob

### DIFF
--- a/returnn/rasr_training.py
+++ b/returnn/rasr_training.py
@@ -273,7 +273,11 @@ class ReturnnRasrTrainingJob(ReturnnTrainingJob):
         train_config, train_post_config = cls.create_config(**kwargs)
         kwargs["crp"] = dev_crp
         dev_config, dev_post_config = cls.create_config(**kwargs)
-        returnn_config = kwargs["returnn_config"]
+
+        datasets = cls.create_dataset_config(train_crp, kwargs["partition_epochs"])
+        kwargs["returnn_config"].config["train"] = datasets["train"]
+        kwargs["returnn_config"].config["dev"] = datasets["dev"]
+        returnn_config = ReturnnTrainingJob.create_returnn_config(**kwargs)
         d = {
             "train_config": train_config,
             "dev_config": dev_config,
@@ -286,8 +290,5 @@ class ReturnnRasrTrainingJob(ReturnnTrainingJob):
 
         if kwargs["additional_rasr_config_files"] is not None:
             d["additional_rasr_config_files"] = kwargs["additional_rasr_config_files"]
-
-        if kwargs["partition_epochs"] is not None:
-            d["partition_epochs"] = kwargs["partition_epochs"]
 
         return Job.hash(d)

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -373,7 +373,7 @@ class ReturnnTrainingJob(Job):
     @classmethod
     def hash(cls, kwargs):
         d = {
-            "returnn_config": kwargs["returnn_config"],
+            "returnn_config": ReturnnTrainingJob.create_returnn_config(**kwargs),
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],
         }


### PR DESCRIPTION
Alternative to #62 (see the discussion for context)

The output of create_returnn_config is now used to get the hash in the ReturnnSearchJob and ReturnnTrainingJob.
This ensures that all changes made to the config in this method change the hash.

**This will change all hashes of train and search jobs.**
