### PR TITLE
returnn config consistency check

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -109,6 +109,7 @@ class ReturnnConfig:
             f.write(self.serialize())
 
     def serialize(self):
+        self.check_consistency()
         config = self.config
         config.update(self.post_config)
 
@@ -185,6 +186,15 @@ class ReturnnConfig:
         if inspect.isclass(code):
             return inspect.getsource(code)
         raise RuntimeError("Could not serialize %s" % code)
+
+    def check_consistency(self):
+        """
+        check that there is no config key overwritten by post_config
+        """
+        for key in self.config:
+            assert (
+                key not in self.post_config
+            ), "%s in post_config would overwrite existing entry in config"
 
     def _sis_hash(self):
         h = {

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -192,9 +192,9 @@ class ReturnnConfig:
         check that there is no config key overwritten by post_config
         """
         for key in self.config:
-            assert (
-                key not in self.post_config
-            ), "%s in post_config would overwrite existing entry in config"
+            assert key not in self.post_config, (
+                "%s in post_config would overwrite existing entry in config" % key
+            )
 
     def _sis_hash(self):
         h = {

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -160,6 +160,7 @@ class ReturnnSearchJob(Job):
         res = copy.deepcopy(returnn_config)
         res.config = config
         res.post_config = post_config
+        res.check_consistency()
 
         return res
 

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -367,6 +367,7 @@ class ReturnnTrainingJob(Job):
 
         res.config = config
         res.post_config = post_config
+        res.check_consisteny()
 
         return res
 


### PR DESCRIPTION
Adds a check that will prohibit accidentally overwriting hashed parameters (in `config`) with unhashed parameters (in `post_config`)

as you did not appear in the reviewer list, also @dthulke and @mattiadg 