### PR TITLE
Adapted function call to new interface that includes returnn_config

### DIFF
--- a/returnn/rasr_training.py
+++ b/returnn/rasr_training.py
@@ -303,7 +303,9 @@ class ReturnnRasrTrainingJob(ReturnnTrainingJob):
         kwargs["crp"] = dev_crp
         dev_config, dev_post_config = cls.create_config(**kwargs)
 
-        datasets = cls.create_dataset_config(train_crp, kwargs["partition_epochs"])
+        datasets = cls.create_dataset_config(
+            train_crp, kwargs["returnn_config"], kwargs["partition_epochs"]
+        )
         kwargs["returnn_config"].config["train"] = datasets["train"]
         kwargs["returnn_config"].config["dev"] = datasets["dev"]
         returnn_config = ReturnnTrainingJob.create_returnn_config(**kwargs)


### PR DESCRIPTION
#79 left `ReturnnRasrTrainingJob` in a wrong state because of the changed interface of `create_dataset_config`.
This fixes the last wrong call to it