### PR TITLE
allow returnn configs with get_network function

### DIFF
--- a/returnn/training.py
+++ b/returnn/training.py
@@ -340,7 +340,10 @@ class ReturnnTrainingJob(Job):
         **kwargs,
     ):
         assert device in ["gpu", "cpu"]
-        assert "network" in returnn_config.config
+        assert "network" in returnn_config.config or "get_network" in [
+            getattr(obj, "__name__", None)
+            for obj in returnn_config.python_prolog.values()
+        ]
 
         res = copy.deepcopy(returnn_config)
 


### PR DESCRIPTION
RETURNN allows using configs which define a function `get_network()` instead of the usual `network`. This should also be allowed in the training job.