### PR TITLE
Add LexiconFromTextFileJob

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -9,7 +9,7 @@ from sisyphus import *
 Path = setup_path(__package__)
 
 import i6_core.lib.lexicon as lexicon
-from i6_core.util import uopen
+from i6_core.util import uopen, write_xml
 
 
 class LexiconToWordListJob(Job):
@@ -185,8 +185,7 @@ class LexiconFromTextFileJob(Job):
                 ]
                 for phon_variant in phon_variants:
                     for phon in phon_variant:
-                        if phon not in phonemes:
-                            phonemes.add(phon)
+                        phonemes.add(phon)
                 phon = [" ".join(v) for v in phon_variants]
                 lemma = lexicon.Lemma(orth=[orth], phon=phon)
                 if last_lemma and lemma.orth[0] == last_lemma.orth[0]:
@@ -198,10 +197,7 @@ class LexiconFromTextFileJob(Job):
         for phoneme in sorted(phonemes):
             lex.add_phoneme(phoneme)
 
-        with uopen(self.out_bliss_lexicon.get_path(), "wb") as lexicon_file:
-            s = ET.tostring(lex.to_xml(), "unicode")
-            pretty_s = minidom.parseString(s).toprettyxml(indent=" ", encoding="utf-8")
-            lexicon_file.write(pretty_s)
+        write_xml(self.out_bliss_lexicon.get_path(), lex.to_xml())
 
 
 class GraphemicLexiconFromWordListJob(Job):

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -185,7 +185,8 @@ class LexiconFromTextFileJob(Job):
                 phon_variants = [
                     tuple(p.split()) for p in s[1].split("\\") if p.strip()
                 ]
-                phonemes.update(phon_variants)
+                for phon_variant in phon_variants:
+                    phonemes.update(phon_variant)
                 phon = [" ".join(v) for v in phon_variants]
                 lemma = lexicon.Lemma(orth=[orth], phon=phon)
                 if last_lemma and lemma.orth[0] == last_lemma.orth[0]:

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -143,10 +143,11 @@ class LexiconUniqueOrthJob(Job):
 class LexiconFromTextFileJob(Job):
     """
     Create a bliss lexicon from a regular text file, where each line contains:
-    < WORD > < PHONEME1 > < PHONEME2 > ...
+    <WORD> <PHONEME1> <PHONEME2> ...
     separated by tabs or spaces.
     The lemmata will be added in the order they appear in the text file,
     the phonemes will be sorted alphabetically.
+    Phoneme variants of the same word need to appear next to each other.
     No special lemmata or phonemes are added.
 
     As the splitting is taken from RASR and not fully tested,

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -148,7 +148,9 @@ class LexiconFromTextFileJob(Job):
     The lemmata will be added in the order they appear in the text file,
     the phonemes will be sorted alphabetically.
     Phoneme variants of the same word need to appear next to each other.
-    No special lemmata or phonemes are added.
+
+    WARNING: No special lemmas or phonemes are added,
+    so do not use this lexicon with RASR directly!
 
     As the splitting is taken from RASR and not fully tested,
     it might not work in all cases so do not use this job
@@ -183,9 +185,7 @@ class LexiconFromTextFileJob(Job):
                 phon_variants = [
                     tuple(p.split()) for p in s[1].split("\\") if p.strip()
                 ]
-                for phon_variant in phon_variants:
-                    for phon in phon_variant:
-                        phonemes.add(phon)
+                phonemes.update(phon_variants)
                 phon = [" ".join(v) for v in phon_variants]
                 lemma = lexicon.Lemma(orth=[orth], phon=phon)
                 if last_lemma and lemma.orth[0] == last_lemma.orth[0]:

--- a/util.py
+++ b/util.py
@@ -205,7 +205,7 @@ def write_xml(filename, element_tree, prettify=True):
     """
     writes element tree to xml file
     :param Union[Path, str] filename: name of desired output file
-    :param ET.ElementTree element_tree: element tree which should be written to file
+    :param ET.ElementTree|ET.Element element_tree: element tree which should be written to file
     :param bool prettify: prettify the xml. Warning: be careful with this option if you care about whitespace in the xml.
     """
 
@@ -219,7 +219,13 @@ def write_xml(filename, element_tree, prettify=True):
             if not re.search(has_non_whitespace, str(element.text)):
                 element.text = ""
 
-    root = element_tree.getroot()
+    if isinstance(element_tree, ET.ElementTree):
+        root = element_tree.getroot()
+    elif isinstance(element_tree, ET.Element):
+        root = element_tree
+    else:
+        assert False, "please provide an ElementTree or Element"
+
     if prettify:
         remove_unwanted_whitespace(root)
         xml_string = xml.dom.minidom.parseString(ET.tostring(root)).toprettyxml(


### PR DESCRIPTION
This is my try to replicate the behavior of the "Pavel"-style Lexicon for LibriSpeech, which means kind of emulating the behavior of very ancient RASR tools that are no longer supported.

As the lexicon format is a quite critical decision for the future I added all of you as reviewers (I could not find Simon and Zijian here)

You can review the files under `/u/rossenbach/stuff/pavel_ls_lexicon_test`:
 - `librispeech-lexicon.txt` the input LibriSpeech lexcion as downloaded from the webpage
 - `orig.xml` the lexicon used until now
 - `test.xml` the lexicon produced by the new job
 
 The documentation for the Bliss-Lexicon can be found here:
 https://www-i6.informatik.rwth-aachen.de/rwth-asr/manual/index.php/Lexicon
 

