### PR TITLE
Added parentheses in CorpusToTxtJob.__init__

### DIFF
--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -114,7 +114,7 @@ class CorpusToTxtJob(Job):
         self.gzip = gzip
         self.segment_file = segment_file
 
-        self.out_txt = self.output_path("corpus.txt" + ".gz" if gzip else "")
+        self.out_txt = self.output_path("corpus.txt" + (".gz" if gzip else ""))
 
     def tasks(self):
         yield Task("run", mini_task=True)


### PR DESCRIPTION
Without the parentheses, if `gzip=False`, the output path is set to an empty string and no output file is created.