### PR TITLE
Add BuildGlobalCacheJob

### DIFF
--- a/rasr/config.py
+++ b/rasr/config.py
@@ -237,7 +237,7 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         config._update(crp.log_config)
         post_config._update(crp.log_post_config)
 
-    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model"]:
+    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model", "recognizer"]:
         if mkey not in mapping:
             continue
         keys = mapping[mkey]

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -22,6 +22,8 @@ class CommonRasrParameters:
             self.lexicon_post_config = None
             self.language_model_config = None
             self.language_model_post_config = None
+            self.recognizer_config = None
+            self.recognizer_post_config = None
             self.log_config = None
             self.log_post_config = None
             self.compress_log_file = True


### PR DESCRIPTION
First step in refactoring recognition pipeline dependencies. Two things that I want to change:
1. recognizer parameters are currently very restricted in the AdvancedTreeSearchJob. This is fixed by providing the recognizer_config via crp.
2. AdvancedTreeSearchLmImageAndGlobalCacheJob does too many things (building global cache + building lm image). Ideally these are two separate steps, s.t. changes to the search space do not trigger a rebuild of the LM image.

This pull request addresses 1. by adding a new member to crp and 2. by adding a separate job for building the global cache.
Next step will be a CreateLmImageJob and after that a AdvancedTreeSearchV2Job.