### PR TITLE
Add support for g2p_path and g2p_python of any DelayedBase subtype

### DIFF
--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -30,8 +30,8 @@ class ApplyG2PModelJob(Job):
         :param Path word_list_file: text file with a word each line
         :param float variants_mass:
         :param int variants_number:
-        :param Path|str|None g2p_path:
-        :param Path|str|None g2p_python:
+        :param DelayedBase|str|None g2p_path:
+        :param DelayedBase|str|None g2p_python:
         """
 
         if g2p_path is None:
@@ -61,8 +61,8 @@ class ApplyG2PModelJob(Job):
         with uopen(self.out_g2p_lexicon, "wt") as out:
             sp.check_call(
                 [
-                    self.g2p_python,
-                    self.g2p_path,
+                    str(self.g2p_python),
+                    str(self.g2p_path),
                     "-e",
                     "utf-8",
                     "-V",

--- a/g2p/train.py
+++ b/g2p/train.py
@@ -40,9 +40,9 @@ class TrainG2PModelJob(Job):
         :param str size_constrains: passed as -s argument,
             multigrams must have l1 ... l2 left-symbols and r1 ... r2 right-symbols
         :param list[str] extra_args: extra cmd arguments that are passed to the g2p process
-        :param Path|str|None g2p_path: path to the g2p installation. If None, searches for a global G2P_PATH,
+        :param DelayedBase|str|None g2p_path: path to the g2p installation. If None, searches for a global G2P_PATH,
             and uses the default binary path if not existing.
-        :param Path|str|None g2p_python: path to the g2p python binary. If None, searches for a global G2P_PYTHON,
+        :param DelayedBase|str|None g2p_python: path to the g2p python binary. If None, searches for a global G2P_PYTHON,
             and uses the default python binary if not existing.
         """
         if extra_args is None:
@@ -92,8 +92,8 @@ class TrainG2PModelJob(Job):
                 continue
 
             args = [
-                self.g2p_python,
-                self.g2p_path,
+                str(self.g2p_python),
+                str(self.g2p_path),
                 "-e",
                 "utf-8",
                 "-i",


### PR DESCRIPTION
Solves #121 and it goes also for `ApplyG2PModelJob`