### PR TITLE
increase Costa default memory

### DIFF
--- a/corpus/costa.py
+++ b/corpus/costa.py
@@ -32,7 +32,7 @@ class CostaJob(rasr.RasrCommand, Job):
         self.rqmt = {
             "time": max(crp.corpus_duration / 20, 0.5),
             "cpu": 1,
-            "mem": 1 if not self.config.costa.lm_statistics else 4,
+            "mem": 1 if not self.config.costa.lm_statistics else 8,
         }
 
     def tasks(self):


### PR DESCRIPTION
The current requirements were not sufficient for LibriSpeech, so I would suggest to increase it rather than fixing it in the pipeline, as this will probably be insufficient for other tasks as well.