### PR TITLE
add dynamic networks to config

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -269,7 +269,7 @@ class ReturnnConfig:
             assert key not in self.post_config, (
                 "%s in post_config would overwrite existing entry in config" % key
             )
-        assert bool(self.staged_network_dict) != bool("network" in self.config)
+        assert not (self.staged_network_dict and "network" in self.config)
 
     def _sis_hash(self):
         h = {

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -107,7 +107,7 @@ class ReturnnConfig:
         :param dict post_config: dictionary of the RETURNN config variables that are not hashed
         :param None|str|Callable|Class|tuple|list|dict python_prolog: str or structure containing str/callables/classes
             that should be pasted as code at the beginning of the config file
-        :param None|dict[dict[Any]]: dictionary of network dictionaries, indexed by the desired starting epoch of the network stage
+        :param None|dict[dict[Any]] staged_network_dict: dictionary of network dictionaries, indexed by the desired starting epoch of the network stage
         :param str|None python_prolog_hash: sets a specific hash for the python_prolog
         :param None|str|Callable|Class|tuple|list|dict python_epilog: str or structure containing
             str/callables/classes that should be pasted as code at the end of the config file

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -74,12 +74,10 @@ class ReturnnConfig:
         
         def get_network(epoch, **kwargs):
           from networks import networks_dict
-          while(True):
-            if epoch in networks_dict:
-              return networks_dict[epoch]
-            else:
-              epoch -= 1
-              assert epoch > 0, \"Error, no networks found\"
+          for epoch_ in sorted(networks_dict.keys(), reverse=True):
+            if epoch_ <= epoch:
+              return networks_dict[epoch_]
+          assert False, \"Error, no networks found\"
         
         """
     )

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -269,6 +269,7 @@ class ReturnnConfig:
             assert key not in self.post_config, (
                 "%s in post_config would overwrite existing entry in config" % key
             )
+        assert bool(self.staged_network_dict) != bool("network" in self.config)
 
     def _sis_hash(self):
         h = {

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -101,6 +101,7 @@ class ReturnnConfig:
         :param dict post_config: dictionary of the RETURNN config variables that are not hashed
         :param None|str|Callable|Class|tuple|list|dict python_prolog: str or structure containing str/callables/classes
             that should be pasted as code at the beginning of the config file
+        :param None|dict[dict[Any]]: dictionary of network dictionaries, indexed by the desired starting epoch of the network stage
         :param str|None python_prolog_hash: sets a specific hash for the python_prolog
         :param None|str|Callable|Class|tuple|list|dict python_epilog: str or structure containing
             str/callables/classes that should be pasted as code at the end of the config file
@@ -134,15 +135,12 @@ class ReturnnConfig:
             return self.post_config[key]
         return self.config.get(key, default)
 
-    def write_network(self, config_path):
+    def _write_network_stages(self, config_path):
         """
         write the networks of the staged network dict into a "networks" folder including
         the access dictionary in the init file
 
         :param str config_path:
-        :param dict network:
-        :param int epoch:
-        :return:
         """
         config_dir = os.path.dirname(config_path)
         network_dir = os.path.join(config_dir, "networks")
@@ -150,7 +148,7 @@ class ReturnnConfig:
             os.mkdir(network_dir)
 
         init_file = os.path.join(network_dir, "__init__.py")
-        init_import_code = "\n"
+        init_import_code = ""
         init_dict_code = "\n\nnetworks_dict = {\n"
 
         for epoch in self.staged_network_dict.keys():
@@ -172,7 +170,7 @@ class ReturnnConfig:
 
     def write(self, path):
         if self.staged_network_dict:
-            self.write_network(path)
+            self._write_network_stages(path)
         with open(path, "wt", encoding="utf-8") as f:
             f.write(self.serialize())
 

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -59,7 +59,8 @@ class ReturnnConfig:
     PYTHON_CODE = textwrap.dedent(
         """\
         #!rnn.py
-    
+        ${SUPPORT_CODE}
+
         ${PROLOG}
     
         ${REGULAR_CONFIG}
@@ -72,6 +73,9 @@ class ReturnnConfig:
 
     GET_NETWORK_CODE = textwrap.dedent(
         """\
+        import os
+        import sys
+        sys.path.insert(0, os.path.dirname(__file__))
         
         def get_network(epoch, **kwargs):
           from networks import networks_dict
@@ -210,16 +214,13 @@ class ReturnnConfig:
         python_prolog_code = self.__parse_python(self.python_prolog)
         python_epilog_code = self.__parse_python(self.python_epilog)
 
+        support_code = ""
         if self.staged_network_dict:
-            config_lines.append(self.GET_NETWORK_CODE)
-
-            python_prolog_code = (
-                "import os\nimport sys\nsys.path.insert(0, os.path.dirname(__file__))\n\n"
-                + python_prolog_code
-            )
+            support_code += self.GET_NETWORK_CODE
 
         python_code = string.Template(self.PYTHON_CODE).substitute(
             {
+                "SUPPORT_CODE": support_code,
                 "PROLOG": python_prolog_code,
                 "REGULAR_CONFIG": "\n".join(config_lines),
                 "EPILOG": python_epilog_code,

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -352,7 +352,6 @@ class ReturnnTrainingJob(Job):
         **kwargs,
     ):
         assert device in ["gpu", "cpu"]
-        assert "network" in returnn_config.config
 
         res = copy.deepcopy(returnn_config)
 


### PR DESCRIPTION
This adds the possibility to do nice pre-training via the ReturnnConfig object. When you have network creation code, you can just alter some parameters for each stage, and then put this in a dictionary with the epoch as key. This gives full flexibility over any kind of curriculum training, and allows to compare stages directly with e.g. vimdiff.

The only missing feature for now is a Task that tests all networks beforehand if there are errors.



