### PR TITLE
fix speaker gender tag

### DIFF
--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -169,7 +169,7 @@ class LibriSpeechCreateBlissCorpusJob(Job):
                 continue
             speaker = corpus.Speaker()
             speaker.name = speaker_id
-            speaker.attribs["gender"] = speaker_info[0].lower()
+            speaker.attribs["gender"] = "male" if speaker_info[0] == "M" else "female"
             c.add_speaker(speaker)
 
         c.dump(self.out_corpus.get_path())


### PR DESCRIPTION
There was an error in the speaker tags that nobody noticed, which causes warnings when running RASR. I will fix this manually in all jobs that are already stored openly for everyone.