### PR TITLE
Log name fixes in advanced_tree_search.py

### DIFF
--- a/features/common.py
+++ b/features/common.py
@@ -17,6 +17,29 @@ __all__ = [
 
 import i6_core.rasr as rasr
 
+# -------------------- Helper -------------------
+
+
+def get_input_node_type(audio_format="wav"):
+    """
+    Gets the RASR flow input node type based on the audio_format
+
+    :param str audio_format:
+    :return: node type
+    :rtype: str
+    """
+    native_audio_formats = [
+        "wav",
+        "nist",
+        "flac",
+        "mpeg",
+        "gsm",
+        "htk",
+        "phondat",
+        "oss",
+    ]
+    return audio_format if audio_format in native_audio_formats else "ffmpeg"
+
 
 # -------------------- Flows --------------------
 
@@ -27,8 +50,10 @@ def raw_audio_flow(audio_format="wav"):
     net.add_output("out")
     net.add_param(["input-file", "start-time", "end-time"])
 
+    input_node_type = get_input_node_type(audio_format)
+
     samples = net.add_node(
-        "audio-input-file-" + audio_format,
+        "audio-input-file-" + input_node_type,
         "samples",
         {
             "file": "$(input-file)",
@@ -94,18 +119,7 @@ def samples_flow(
     if input_options is not None:
         input_opts.update(**input_options)
 
-    native_audio_formats = [
-        "wav",
-        "nist",
-        "flac",
-        "mpeg",
-        "gsm",
-        "htk",
-        "phondat",
-        "oss",
-    ]
-
-    input_node_type = audio_format if audio_format in native_audio_formats else "ffmpeg"
+    input_node_type = get_input_node_type(audio_format)
 
     samples = net.add_node("audio-input-file-" + input_node_type, "samples", input_opts)
     if input_node_type == "ffmpeg":

--- a/lm/__init__.py
+++ b/lm/__init__.py
@@ -1,2 +1,3 @@
 from .perplexity import *
 from .reverse_arpa import *
+from .lm_image import *

--- a/lm/lm_image.py
+++ b/lm/lm_image.py
@@ -29,7 +29,7 @@ class LmImageJob(rasr.RasrCommand, Job):
         self.exe = self.select_exe(crp.lm_util_exe, "lm-util")
 
         self.log_file = self.log_file_output_path("lm_image", crp, False)
-        self.out = self.output_path("lm.image", cached=True)
+        self.out_image = self.output_path("lm.image", cached=True)
 
         self.rqmt = {"time": 1, "cpu": 1, "mem": mem}
 
@@ -51,6 +51,7 @@ class LmImageJob(rasr.RasrCommand, Job):
 
     def run(self):
         self.run_script(1, self.log_file)
+        shutil.move("lm.image.1", self.out_image.get_path())
 
     def cleanup_before_run(self, cmd, retry, *args):
         util.backup_if_exists("lm_image.log")

--- a/lm/lm_image.py
+++ b/lm/lm_image.py
@@ -1,0 +1,112 @@
+__all__ = ["LmImageJob"]
+
+import shutil
+
+from sisyphus import *
+from i6_core import rasr
+from i6_core import util
+
+Path = setup_path(__package__)
+
+
+class LmImageJob(rasr.RasrCommand, Job):
+    def __init__(
+        self,
+        crp,
+        text_file,
+        extra_config=None,
+        extra_post_config=None,
+        encoding="utf-8",
+        renormalize=False,
+    ):
+        kwargs = locals()
+        del kwargs["self"]
+
+        self.text_file = text_file
+        self.renormalize = renormalize
+
+        self.config, self.post_config, self.num_images = LmImageJob.create_config(
+            **kwargs
+        )
+        self.exe = self.select_exe(crp.lm_util_exe, "lm-util")
+
+        self.log_file = self.log_file_output_path("lm_image", crp, False)
+        self.lm_images = {
+            i: self.output_path(f"lm-{i}.image", cached=True)
+            for i in range(1, self.num_images + 1)
+        }
+
+        self.rqmt = {"time": 1, "cpu": 1, "mem": 2}
+
+    def tasks(self):
+        yield Task("create_files", resume="create_files", mini_task=True)
+        yield Task("run", resume="run", rqmt=self.rqmt)
+
+    def create_files(self):
+        self.write_config(self.config, self.post_config, "lm_image.config")
+        device = "gpu" if self.rqmt.get("gpu", 0) > 0 else "cpu"
+        extra_code = (
+            f":${{THEANO_FLAGS:="
+            '}\nexport THEANO_FLAGS="$THEANO_FLAGS,device={device},force_device=True"\nexport TF_DEVICE="{device}"'
+        )
+        self.write_run_script(self.exe, "lm_image.config", extra_code=extra_code)
+
+    def run(self):
+        self.run_script(1, self.log_file)
+        for i in range(1, self.num_images + 1):
+            shutil.move(f"lm-{i}.image", self.lm_images[i].get_path())
+
+    def cleanup_before_run(self, cmd, retry, *args):
+        util.backup_if_exists("lm_image.log")
+
+    @classmethod
+    def find_arpa_lms(cls, lm_config, lm_post_config=None):
+        result = []
+
+        def has_image(c, pc):
+            res = c._get("image") is not None
+            res = res or (pc is not None and pc._get("image") is not None)
+            return res
+
+        if lm_config.type == "ARPA":
+            if not has_image(lm_config, lm_post_config):
+                result.append((lm_config, lm_post_config))
+        elif lm_config.type == "combine":
+            for i in range(1, lm_config.num_lms + 1):
+                sub_lm_config = lm_config["lm-%d" % i]
+                sub_lm_post_config = (
+                    lm_post_config["lm-%d" % i] if lm_post_config is not None else None
+                )
+                result += cls.find_arpa_lms(sub_lm_config, sub_lm_post_config)
+        return result
+
+    @classmethod
+    def create_config(
+        cls,
+        crp,
+        text_file,
+        extra_config,
+        extra_post_config,
+        encoding,
+        renormalize,
+        **kwargs,
+    ):
+        config, post_config = rasr.build_config_from_mapping(
+            crp, {"lexicon": "lm-util.lexicon", "language_model": "lm-util.lm"}
+        )
+        del (
+            config.lm_util.lm.scale
+        )  # scale not considered here, delete to remove ambiguity
+
+        config.lm_util.action = "load-lm"
+        config.lm_util.file = text_file
+        config.lm_util.encoding = encoding
+        config.lm_util.batch_size = 100
+        config.lm_util.renormalize = renormalize
+
+        config._update(extra_config)
+        post_config._update(extra_post_config)
+
+        arpa_lms = cls.find_arpa_lms(config, post_config if post_config else None,)
+
+        return config, post_config, len(arpa_lms)

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -34,7 +34,7 @@ class AdvancedTreeSearchLmImageAndGlobalCacheJob(rasr.RasrCommand, Job):
         ) = AdvancedTreeSearchLmImageAndGlobalCacheJob.create_config(**kwargs)
         self.exe = self.select_exe(crp.flf_tool_exe, "flf-tool")
 
-        self.log_file = self.log_file_output_path("lm_and_state_tree", crp, False)
+        self.log_file = self.log_file_output_path("lm_and_global_cache", crp, False)
         self.lm_images = {
             i: self.output_path("lm-%d.image" % i, cached=True)
             for i in range(1, self.num_images + 1)
@@ -198,7 +198,7 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         self.concurrent = crp.concurrent
         self.use_gpu = use_gpu
 
-        self.log_file = self.log_file_output_path("search", crp, True)
+        self.log_file = self.log_file_output_path("recognition", crp, True)
         self.single_lattice_caches = dict(
             (task_id, self.output_path("lattice.cache.%d" % task_id, cached=True))
             for task_id in range(1, crp.concurrent + 1)
@@ -582,7 +582,7 @@ class BidirectionalAdvancedTreeSearchJob(rasr.RasrCommand, Job):
         self.concurrent = crp.concurrent
         self.use_gpu = use_gpu
 
-        self.log_file = self.log_file_output_path("search", crp, True)
+        self.log_file = self.log_file_output_path("recognition", crp, True)
         self.single_lattice_caches = dict(
             (task_id, self.output_path("lattice.cache.%d" % task_id, cached=True))
             for task_id in range(1, crp.concurrent + 1)


### PR DESCRIPTION
Change the log file names so that they are consistent in `log_file_output_path` and `cleanup_before_run`