### PR TITLE
add guideline for naming different corpus variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,4 +58,11 @@ Create an executable `.git/hook/pre-commit` with:
     black --check .
     exit 0
 
+Corpus variable naming
 
+    corpus_key -> str (basically corpus identifier)
+    corpus_object -> CorpusObject
+    corpus_file -> Path (would be filepath)
+    corpus_config -> RasrConfig describing the corpus
+
+    corpus any, but usage is discouraged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Create an executable `.git/hook/pre-commit` with:
     black --check .
     exit 0
 
-Corpus variable naming
+Corpus variable naming: in sisyphus setups there are different ways to hold the corpus information (str, Path, CorpusObject, RasrConfig). At the moment `corpus` covers all. To distinguish the different forms to hold the corpus information, we strongly encourage using the following variable naming:
 
     corpus_key -> str (basically corpus identifier)
     corpus_object -> CorpusObject

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ e.g. in the setup root call:
 # Contributing
 
 Before contributing to `i6_core`, please have a close look at
-[CONTRIBUTING.md](https://github.com/rwth-i6/i6_core/blob/main/CONTRIBUTUNG.md)
+[CONTRIBUTING.md](https://github.com/rwth-i6/i6_core/blob/main/CONTRIBUTING.md)
 
 Code style: https://github.com/psf/black
 


### PR DESCRIPTION
adds documentation for the discussion in issue #171 