### PR TITLE
removes tk.uncached from hash call

### DIFF
--- a/recognition/optimize_parameters.py
+++ b/recognition/optimize_parameters.py
@@ -216,7 +216,7 @@ class OptimizeAMandLMScaleJob(rasr.RasrCommand, Job):
             "exe": kwargs["crp"].flf_tool_exe,
             "initial_am_scale": kwargs["initial_am_scale"],
             "initial_lm_scale": kwargs["initial_lm_scale"],
-            "lattice_cache": tk.uncached_path(kwargs["lattice_cache"]),
+            "lattice_cache": kwargs["lattice_cache"],
             "scorer_cls": kwargs["scorer_cls"],
             "scorer_kwargs": kwargs["scorer_kwargs"],
         }


### PR DESCRIPTION
OptimizeAMandLMScaleJob has a `tk.uncached_path` call in the hash creation, making the hash dependent on an absolute path. call to `tk.uncached_path` removed.