### PR TITLE
Change Lexicon to only allow a single sequence of synt tokens - Updated

### DIFF
--- a/bpe/apply.py
+++ b/bpe/apply.py
@@ -48,9 +48,8 @@ class ApplyBPEModelToLexiconJob(Job):
         for l in lexicon.lemmata:
             for orth in l.orth:
                 lm_tokens.add(orth)
-            for synt in l.synt:
-                for t in synt:
-                    lm_tokens.add(t)
+            for token in l.synt or []:  # l.synt can be None
+                lm_tokens.add(token)
             for eval in l.eval:
                 for t in eval:
                     lm_tokens.add(t)
@@ -85,15 +84,12 @@ class ApplyBPEModelToLexiconJob(Job):
 
         for l in lexicon.lemmata:
             if l.special is None and len(l.orth) > 0:
-                if len(l.synt) == 0 and len(l.eval) == 0:
+                if not l.synt and len(l.eval) == 0:
                     o = l.orth[0]
-                    l.synt.append(w2b[o])
+                    l.synt = w2b[o]
                     l.eval.append([o])
-                if len(l.synt) > 0:
-                    l.synt = [
-                        sum([w2b[t] for t in token_sequence], [])
-                        for token_sequence in l.synt
-                    ]
+                if l.synt:
+                    l.synt = sum([w2b[token] for token in l.synt], [])
                 if len(l.eval) > 0:
                     l.eval = [
                         sum([w2b[t] for t in token_sequence], [])

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -241,15 +241,18 @@ class GraphemicLexiconFromWordListJob(Job):
         if self.add_noise:
             lex.add_phoneme("noise", "none")
 
+        # TODO: figure out requirements on synt/eval element for differnt types of lemmata
+        # silence lemma, needs synt/eval element with empty token sequence
         lex.add_lemma(
             lexicon.Lemma(
                 orth=["[SILENCE]", ""],
                 phon=["sil"],
-                synt=[""],
+                synt=[],
                 special="silence",
-                eval=[""],
+                eval=[[]],
             )
         )
+        # sentence border lemmata, needs no eval element
         lex.add_lemma(
             lexicon.Lemma(
                 orth=["[SENTENCE_BEGIN]"], synt=["<s>"], special="sentence-begin"
@@ -260,14 +263,20 @@ class GraphemicLexiconFromWordListJob(Job):
                 orth=["[SENTENCE_END]"], synt=["</s>"], special="sentence-end"
             )
         )
+        # unknown lemma, needs no synt/eval element
         if self.add_unknown:
             lex.add_lemma(
                 lexicon.Lemma(orth=["[UNKNOWN]"], phon=["unk"], special="unknown")
             )
+            # TODO: synt = ["<UNK>"] ???
+        # noise lemma, needs empty synt token sequence but no eval element?
         if self.add_noise:
             lex.add_lemma(
                 lexicon.Lemma(
-                    orth=["[NOISE]"], phon=["noise"], synt=[""], special="unknown"
+                    orth=["[NOISE]"],
+                    phon=["noise"],
+                    synt=[],
+                    special="unknown",
                 )
             )
 

--- a/lexicon/modification.py
+++ b/lexicon/modification.py
@@ -24,16 +24,24 @@ class WriteLexiconJob(Job):
             static_lexiconicon.Lemma(
                 orth=["[SILENCE]", ""],
                 phon=["[SILENCE]"],
-                synt=[""],
+                synt=[],
                 special="silence",
-                eval=[""],
+                eval=[[]],
             )
         )
+        # set synt and eval carefully
+        # synt == None   --> nothing                 no synt element
+        # synt == []     --> "<synt />"              meant to be empty synt token sequence
+        # synt == [""]   --> "<synt><tok /></synt>"  incorrent
+        # eval == []     --> nothing                 no eval element
+        # eval == [[]]   --> "<eval />"              meant to be empty eval token sequence
+        # eval == [""]   --> "<eval />"              equivalent to [[]], but not encouraged
+        # eval == [[""]] --> "<eval><tok /></eval>"  incorrect
         static_lexicon.add_lemma(
             static_lexiconicon.Lemma(
                 orth=["[UNKNOWN]"],
                 phon=["[UNKNOWN]"],
-                synt=[["<UNK>"]],
+                synt=["<UNK>"],
                 special="unknown",
             )
         )

--- a/lib/lexicon.py
+++ b/lib/lexicon.py
@@ -36,6 +36,11 @@ class Lemma:
         self.synt = synt
         self.eval = [] if eval is None else eval
         self.special = special
+        if isinstance(synt, list):
+            assert not (len(synt) > 0 and isinstance(synt[0], list)), (
+                "providing list of list is no longer supported for the 'synt' parameter "
+                "and can be safely changed into a single list"
+            )
 
     def to_xml(self):
         """

--- a/lib/lexicon.py
+++ b/lib/lexicon.py
@@ -6,9 +6,10 @@ For format details visit: `https://www-i6.informatik.rwth-aachen.de/rwth-asr/man
 __all__ = ["Lemma", "Lexicon"]
 
 from collections import OrderedDict
-import gzip
 from typing import Optional, List
 import xml.etree.ElementTree as ET
+
+from i6_core.util import uopen
 
 
 class Lemma:
@@ -21,8 +22,8 @@ class Lemma:
         :param Optional[list[str]] orth: list of spellings used in the training data
         :param Optional[list[str]] phon: list of pronunciation variants. Each str should
             contain a space separated string of phonemes from the phoneme-inventory.
-        :param Optional[list[list[str]]] synt: list of token sequences, for which each token sequence is used as as possible language model representation.
-            Each sublist should contain words from the language model vocabulary.
+        :param Optional[list[str]] synt: list of LM tokens that form a single token sequence.
+            This sequence is used as the language model representation.
         :param Optional[list[list[str]]] eval: list of output representations. Each
             sublist should contain one possible transcription (token sequence) of this lemma
             that is scored against the reference transcription.
@@ -32,7 +33,7 @@ class Lemma:
         """
         self.orth = [] if orth is None else orth
         self.phon = [] if phon is None else phon
-        self.synt = [] if synt is None else synt
+        self.synt = synt
         self.eval = [] if eval is None else eval
         self.special = special
 
@@ -49,17 +50,16 @@ class Lemma:
         for p in self.phon:
             el = ET.SubElement(res, "phon")
             el.text = p
-        for s in self.synt:
+        if self.synt is not None:
             el = ET.SubElement(res, "synt")
-            for t in s:
+            for token in self.synt:
                 el2 = ET.SubElement(el, "tok")
-                el2.text = t
+                el2.text = token
         for e in self.eval:
             el = ET.SubElement(res, "eval")
             for t in e:
                 el2 = ET.SubElement(el, "tok")
                 el2.text = t
-
         return res
 
     @classmethod
@@ -97,7 +97,7 @@ class Lemma:
                     token_element.text.strip() if token_element.text is not None else ""
                 )
             eval.append(tokens)
-        return Lemma(orth, phon, synt, eval, special)
+        return Lemma(orth, phon, synt[0], eval, special)
 
 
 class Lexicon:
@@ -136,9 +136,7 @@ class Lexicon:
         """
         :param str path: bliss lexicon .xml or .xml.gz file
         """
-        open_fun = gzip.open if path.endswith(".gz") else open
-
-        with open_fun(path, "rt") as f:
+        with uopen(path, "rt") as f:
             root = ET.parse(f)
 
         for phoneme in root.findall(".//phoneme-inventory/phoneme"):


### PR DESCRIPTION
I now decided to still "break" hashes in a sense that without adapting the lexicon it will have different hashes, but it gives an assertion warning so people can adjust to the correct type, and then the hashes are the same as before.