### PR TITLE
Fix hash in StringWrapper

### DIFF
--- a/rasr/config.py
+++ b/rasr/config.py
@@ -307,9 +307,22 @@ class ConfigBuilder:
 
 
 class StringWrapper:
+    """
+    Allows to define custom strings for RASR configs with correct hashing,
+    this is somewhat redundant with DelayedFormat from Sisyphus
+    """
+
     def __init__(self, string, hidden=None):
+        """
+
+        :param str string: some string based on the hashing object
+        :param Any hidden: hashing object
+        """
         self.string = string
         self.hidden = hidden
 
     def __str__(self):
         return self.string
+
+    def __sis_state__(self):
+        return {"hidden": self.hidden}


### PR DESCRIPTION
This is a hash-breaking PR, but in the way the StringWrapper is currently used you can have absolute paths hashed which makes setups non-consistent. Maybe it is fine to just keep it as it is, but then everybody should change to `DelayedFormat` or so for modifying paths that are added to RASR configs.