### PR TITLE
make ApplyG2pJob not a mini_task, since it can be quite long

### DIFF
--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -57,7 +57,7 @@ class ApplyG2PModelJob(Job):
         self.rqmt = {"cpu": 1, "mem": 1, "time": 2}
 
     def tasks(self):
-        yield Task("run")
+        yield Task("run", rqmt=self.rqmt)
 
     def run(self):
         with uopen(self.out_g2p_lexicon, "wt") as out:

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -54,6 +54,8 @@ class ApplyG2PModelJob(Job):
 
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
 
+        self.rqmt = {"cpu": 1, "mem": 1, "time": 2}
+
     def tasks(self):
         yield Task("run")
 

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -55,7 +55,7 @@ class ApplyG2PModelJob(Job):
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
 
     def tasks(self):
-        yield Task("run", mini_task=True)
+        yield Task("run")
 
     def run(self):
         with uopen(self.out_g2p_lexicon, "wt") as out:


### PR DESCRIPTION
This job can take also hours to finish, according to the vocabulary size. 
I think it's better not to have it as a mini_task