### PR TITLE
Add parallel and indirect options to FeatureExtractionJob

### DIFF
--- a/features/common.py
+++ b/features/common.py
@@ -181,9 +181,7 @@ def feature_extraction_cache_flow(
         out_path = name + ".cache.$(TASK)"
         if out_dir is not None:
             out_path = os.path.join(out_dir, out_path)
-        fc = net.add_node(
-            "generic-cache", node_name, {"id": "$(id)", "path": out_path}
-        )
+        fc = net.add_node("generic-cache", node_name, {"id": "$(id)", "path": out_path})
         for src in feature_net.get_output_links(port):
             net.link(node_mapping[src], fc)
 

--- a/features/common.py
+++ b/features/common.py
@@ -15,8 +15,6 @@ __all__ = [
     "select_features",
 ]
 
-import os
-
 import i6_core.rasr as rasr
 
 # -------------------- Helper -------------------
@@ -156,13 +154,12 @@ def samples_flow(
 
 
 def feature_extraction_cache_flow(
-    feature_net, port_name_mapping, one_dimensional_outputs=None, out_dir=None
+    feature_net, port_name_mapping, one_dimensional_outputs=None
 ):
     """
     :param rasr.FlowNetwork feature_net: feature flow to extract features from
     :param dict[str,str] port_name_mapping: maps output ports to names of the cache files
     :param set[str]|None one_dimensional_outputs: output ports that return one-dimensional features (e.g. energy)
-    :param Optional[str] out_dir: output folder for feature caches, if not set defaults to current working directory
     :rtype: rasr.FlowNetwork
     """
     if one_dimensional_outputs is None:
@@ -178,10 +175,9 @@ def feature_extraction_cache_flow(
     caches = []
     for port, name in port_name_mapping.items():
         node_name = "feature-cache-" + name
-        out_path = name + ".cache.$(TASK)"
-        if out_dir is not None:
-            out_path = os.path.join(out_dir, out_path)
-        fc = net.add_node("generic-cache", node_name, {"id": "$(id)", "path": out_path})
+        fc = net.add_node(
+            "generic-cache", node_name, {"id": "$(id)", "path": name + ".cache.$(TASK)"}
+        )
         for src in feature_net.get_output_links(port):
             net.link(node_mapping[src], fc)
 

--- a/features/common.py
+++ b/features/common.py
@@ -15,6 +15,8 @@ __all__ = [
     "select_features",
 ]
 
+import os
+
 import i6_core.rasr as rasr
 
 # -------------------- Helper -------------------
@@ -154,12 +156,13 @@ def samples_flow(
 
 
 def feature_extraction_cache_flow(
-    feature_net, port_name_mapping, one_dimensional_outputs=None
+    feature_net, port_name_mapping, one_dimensional_outputs=None, out_dir=None
 ):
     """
-    :param rasr.FlowNetwork feature_net:
-    :param dict[str,str] port_name_mapping:
-    :param set[str]|None one_dimensional_outputs:
+    :param rasr.FlowNetwork feature_net: feature flow to extract features from
+    :param dict[str,str] port_name_mapping: maps output ports to names of the cache files
+    :param set[str]|None one_dimensional_outputs: output ports that return one-dimensional features (e.g. energy)
+    :param Optional[str] out_dir: output folder for feature caches, if not set defaults to current working directory
     :rtype: rasr.FlowNetwork
     """
     if one_dimensional_outputs is None:
@@ -175,8 +178,11 @@ def feature_extraction_cache_flow(
     caches = []
     for port, name in port_name_mapping.items():
         node_name = "feature-cache-" + name
+        out_path = name + ".cache.$(TASK)"
+        if out_dir is not None:
+            out_path = os.path.join(out_dir, out_path)
         fc = net.add_node(
-            "generic-cache", node_name, {"id": "$(id)", "path": name + ".cache.$(TASK)"}
+            "generic-cache", node_name, {"id": "$(id)", "path": out_path}
         )
         for src in feature_net.get_output_links(port):
             net.link(node_mapping[src], fc)

--- a/features/energy.py
+++ b/features/energy.py
@@ -19,11 +19,6 @@ def EnergyJob(crp, energy_options=None, **kwargs):
 
     port_name_mapping = {"energy": "energy"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/energy.py
+++ b/features/energy.py
@@ -7,7 +7,7 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def EnergyJob(crp, energy_options=None, extra_config=None, extra_post_config=None):
+def EnergyJob(crp, energy_options=None, **kwargs):
     if energy_options is None:
         energy_options = {}
     else:
@@ -19,15 +19,17 @@ def EnergyJob(crp, energy_options=None, extra_config=None, extra_post_config=Non
 
     port_name_mapping = {"energy": "energy"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="Energy",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/features/extraction.py
+++ b/features/extraction.py
@@ -56,7 +56,10 @@ class FeatureExtractionJob(rasr.RasrCommand, Job):
         self.config, self.post_config = FeatureExtractionJob.create_config(**kwargs)
         self.feature_flow = feature_flow
         self.cached_feature_flow = feature_extraction_cache_flow(
-            feature_flow, port_name_mapping, one_dimensional_outputs, "$(OUTPUT-DIR)" if indirect_write else None
+            feature_flow,
+            port_name_mapping,
+            one_dimensional_outputs,
+            "$(OUTPUT-DIR)" if indirect_write else None,
         )
         self.exe = (
             crp.feature_extraction_exe
@@ -98,7 +101,11 @@ class FeatureExtractionJob(rasr.RasrCommand, Job):
     def tasks(self):
         yield Task("create_files", mini_task=True)
         yield Task(
-            "run", resume="run", rqmt=self.rqmt, args=range(1, self.concurrent + 1), parallel=self.parallel
+            "run",
+            resume="run",
+            rqmt=self.rqmt,
+            args=range(1, self.concurrent + 1),
+            parallel=self.parallel,
         )
 
     def run(self, task_id):
@@ -151,7 +158,11 @@ class FeatureExtractionJob(rasr.RasrCommand, Job):
         config, post_config = rasr.build_config_from_mapping(
             crp, {"corpus": "extraction.corpus"}, parallelize=True
         )
-        post_config["*"].OUTPUT_DIR = "./"  # make path very unspecific to allow easy override via command-line
+        post_config[
+            "*"
+        ].OUTPUT_DIR = (
+            "./"  # make path very unspecific to allow easy override via command-line
+        )
         config.extraction.feature_extraction.file = "feature-extraction.flow"
         # this was a typo but we cannot remove it now without breaking a lot of hashes
         config.extraction.feature_etxraction["*"].allow_overwrite = True

--- a/features/extraction.py
+++ b/features/extraction.py
@@ -161,7 +161,7 @@ class FeatureExtractionJob(rasr.RasrCommand, Job):
         post_config[
             "*"
         ].OUTPUT_DIR = (
-            "./"  # make path very unspecific to allow easy override via command-line
+            "."  # make path very unspecific to allow easy override via command-line
         )
         config.extraction.feature_extraction.file = "feature-extraction.flow"
         # this was a typo but we cannot remove it now without breaking a lot of hashes

--- a/features/filterbank.py
+++ b/features/filterbank.py
@@ -28,11 +28,6 @@ def FilterbankJob(crp, filterbank_options=None, **kwargs):
 
     port_name_mapping = {"features": "fb"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/filterbank.py
+++ b/features/filterbank.py
@@ -10,13 +10,11 @@ import i6_core.rasr as rasr
 
 
 def FilterbankJob(
-    crp, filterbank_options=None, extra_config=None, extra_post_config=None
+    crp, filterbank_options=None, **kwargs
 ):
     """
     :param rasr.crp.CommonRasrParameters crp:
     :param dict[str, Any]|None filterbank_options:
-    :param rasr.config.RasrConfig|None extra_config:
-    :param rasr.config.RasrConfig|None extra_post_config:
     :return: Feature extraction job with filterbank flow
     :rtype: FeatureExtractionJob
     """
@@ -32,15 +30,17 @@ def FilterbankJob(
 
     port_name_mapping = {"features": "fb"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="filterbank",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/features/filterbank.py
+++ b/features/filterbank.py
@@ -9,9 +9,7 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def FilterbankJob(
-    crp, filterbank_options=None, **kwargs
-):
+def FilterbankJob(crp, filterbank_options=None, **kwargs):
     """
     :param rasr.crp.CommonRasrParameters crp:
     :param dict[str, Any]|None filterbank_options:

--- a/features/gammatone.py
+++ b/features/gammatone.py
@@ -19,11 +19,6 @@ def GammatoneJob(crp, gt_options=None, **kwargs):
 
     port_name_mapping = {"features": "gt"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/gammatone.py
+++ b/features/gammatone.py
@@ -7,7 +7,7 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def GammatoneJob(crp, gt_options=None, extra_config=None, extra_post_config=None):
+def GammatoneJob(crp, gt_options=None, **kwargs):
     if gt_options is None:
         gt_options = {}
     else:
@@ -19,15 +19,17 @@ def GammatoneJob(crp, gt_options=None, extra_config=None, extra_post_config=None
 
     port_name_mapping = {"features": "gt"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="Gammatone",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/features/mfcc.py
+++ b/features/mfcc.py
@@ -31,11 +31,7 @@ def MfccJob(crp, mfcc_options=None, **kwargs):
         kwargs["mem"] = 2
 
     return FeatureExtractionJob(
-        crp,
-        feature_flow,
-        port_name_mapping,
-        job_name="MFCC",
-        **kwargs
+        crp, feature_flow, port_name_mapping, job_name="MFCC", **kwargs
     )
 
 

--- a/features/mfcc.py
+++ b/features/mfcc.py
@@ -25,11 +25,6 @@ def MfccJob(crp, mfcc_options=None, **kwargs):
 
     port_name_mapping = {"features": "mfcc"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp, feature_flow, port_name_mapping, job_name="MFCC", **kwargs
     )

--- a/features/mfcc.py
+++ b/features/mfcc.py
@@ -7,12 +7,10 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def MfccJob(crp, mfcc_options=None, extra_config=None, extra_post_config=None):
+def MfccJob(crp, mfcc_options=None, **kwargs):
     """
     :param rasr.crp.CommonRasrParameters crp:
     :param dict[str] mfcc_options:
-    :param rasr.config.RasrConfig|None extra_config:
-    :param rasr.config.RasrConfig|None extra_post_config:
     :rtype: FeatureExtractionJob
     """
     if mfcc_options is None:
@@ -27,15 +25,17 @@ def MfccJob(crp, mfcc_options=None, extra_config=None, extra_post_config=None):
 
     port_name_mapping = {"features": "mfcc"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="MFCC",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs
     )
 
 

--- a/features/mrasta.py
+++ b/features/mrasta.py
@@ -8,7 +8,7 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def MrastaJob(crp, mrasta_options=None, extra_config=None, extra_post_config=None):
+def MrastaJob(crp, mrasta_options=None, **kwargs):
     if mrasta_options is None:
         mrasta_options = {}
     else:
@@ -20,15 +20,17 @@ def MrastaJob(crp, mrasta_options=None, extra_config=None, extra_post_config=Non
 
     port_name_mapping = {"features-0": "high", "features-1": "low"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="Mrasta",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/features/mrasta.py
+++ b/features/mrasta.py
@@ -20,11 +20,6 @@ def MrastaJob(crp, mrasta_options=None, **kwargs):
 
     port_name_mapping = {"features-0": "high", "features-1": "low"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/plp.py
+++ b/features/plp.py
@@ -8,9 +8,7 @@ from math import log, sqrt, floor
 import i6_core.rasr as rasr
 
 
-def PlpJob(
-    crp, sampling_rate, plp_options=None, **kwargs
-):
+def PlpJob(crp, sampling_rate, plp_options=None, **kwargs):
     if plp_options is None:
         plp_options = {}
     else:

--- a/features/plp.py
+++ b/features/plp.py
@@ -21,11 +21,6 @@ def PlpJob(crp, sampling_rate, plp_options=None, **kwargs):
 
     port_name_mapping = {"features": "plp"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/plp.py
+++ b/features/plp.py
@@ -9,7 +9,7 @@ import i6_core.rasr as rasr
 
 
 def PlpJob(
-    crp, sampling_rate, plp_options=None, extra_config=None, extra_post_config=None
+    crp, sampling_rate, plp_options=None, **kwargs
 ):
     if plp_options is None:
         plp_options = {}
@@ -23,15 +23,17 @@ def PlpJob(
 
     port_name_mapping = {"features": "plp"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="PLP",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/features/voiced.py
+++ b/features/voiced.py
@@ -17,11 +17,6 @@ def VoicedJob(crp, voiced_options=None, **kwargs):
 
     port_name_mapping = {"voiced": "voiced"}
 
-    if "rtf" not in kwargs:
-        kwargs["rtf"] = 0.1
-    if "mem" not in kwargs:
-        kwargs["mem"] = 2
-
     return FeatureExtractionJob(
         crp,
         feature_flow,

--- a/features/voiced.py
+++ b/features/voiced.py
@@ -5,7 +5,7 @@ from .extraction import *
 import i6_core.rasr as rasr
 
 
-def VoicedJob(crp, voiced_options=None, extra_config=None, extra_post_config=None):
+def VoicedJob(crp, voiced_options=None, **kwargs):
     if voiced_options is None:
         voiced_options = {}
     else:
@@ -17,15 +17,17 @@ def VoicedJob(crp, voiced_options=None, extra_config=None, extra_post_config=Non
 
     port_name_mapping = {"voiced": "voiced"}
 
+    if "rtf" not in kwargs:
+        kwargs["rtf"] = 0.1
+    if "mem" not in kwargs:
+        kwargs["mem"] = 2
+
     return FeatureExtractionJob(
         crp,
         feature_flow,
         port_name_mapping,
         job_name="Energy",
-        rtf=0.1,
-        mem=2,
-        extra_config=extra_config,
-        extra_post_config=extra_post_config,
+        **kwargs,
     )
 
 

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -46,7 +46,7 @@ class RasrCommand:
             f.write(repr(config))
 
     @staticmethod
-    def write_run_script(exe, config, filename="run.sh", extra_code=""):
+    def write_run_script(exe, config, filename="run.sh", extra_code="", extra_args=""):
         """
         :param str exe:
         :param str config:
@@ -76,9 +76,9 @@ fi
 
 %s
 
-%s --config=%s --*.TASK=$TASK --*.LOGFILE=$LOGFILE $@\
+%s --config=%s --*.TASK=$TASK --*.LOGFILE=$LOGFILE %s $@\
               """
-                % (extra_code, exe, config)
+                % (extra_code, exe, config, extra_args)
             )
             os.chmod(filename, 0o755)
 


### PR DESCRIPTION
The idea behind this PR is to have less write load on the fileservers while reading the feature caches and also have a mechanism to limit total load.

This PR might break some usage of the FeatureExtractionJob as the order of arguments has changed, but usage via meta.System is unaffected as additional parameters are passed as keyword arguments.