### PR TITLE
make feature extraction tmp_dir consistent to tk.mktemp

### DIFF
--- a/features/extraction.py
+++ b/features/extraction.py
@@ -144,7 +144,7 @@ class FeatureExtractionJob(rasr.RasrCommand, Job):
 
     def run(self, task_id):
         if self.indirect_write:
-            tmp_dir = tempfile.TemporaryDirectory()
+            tmp_dir = tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX)
             out_dir = tmp_dir.name
             args = [out_dir]
         else:


### PR DESCRIPTION
With this fix, the temporary files created by feature extraction are stored in a user definable location which is consistent with other Sisyphus related temp files.

cf. https://github.com/rwth-i6/sisyphus/blob/fe8ad9fb112672546ec2fc4f180df7610c88b372/sisyphus/global_settings.py#L272
https://github.com/rwth-i6/sisyphus/blob/fe8ad9fb112672546ec2fc4f180df7610c88b372/sisyphus/toolkit.py#L82-L105