### PR TITLE
fix keep_epochs behavior in ReturnnTrainingJob

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -287,13 +287,24 @@ class ReturnnConfig:
 
     def check_consistency(self):
         """
-        check that there is no config key overwritten by post_config
+        Check that there is no config key overwritten by post_config.
+        Also check for parameters that should never be hashed.
         """
         for key in self.config:
             assert key not in self.post_config, (
                 "%s in post_config would overwrite existing entry in config" % key
             )
         assert not (self.staged_network_dict and "network" in self.config)
+
+        # list of parameters that should never be hashed
+        disallowed_in_config = [
+            "cleanup_old_models",
+            "log_verbosity",
+        ]
+        for key in disallowed_in_config:
+            assert self.config.get(key) is None, (
+                "please define %s only as parameter in the post_config" % key
+            )
 
     def _sis_hash(self):
         h = {

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -369,7 +369,7 @@ class ReturnnTrainingJob(Job):
         if returnn_config.post_config is not None:
             post_config.update(copy.deepcopy(returnn_config.post_config))
 
-        if keep_epochs:
+        if keep_epochs is not None:
             if not "cleanup_old_models" in post_config or isinstance(
                 post_config["cleanup_old_models"], bool
             ):

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -368,9 +368,17 @@ class ReturnnTrainingJob(Job):
             post_config.update(copy.deepcopy(returnn_config.post_config))
 
         if keep_epochs:
-            if isinstance(post_config["cleanup_old_models"], bool):
+            if not "cleanup_old_models" in post_config or isinstance(
+                post_config["cleanup_old_models"], bool
+            ):
+                assert (
+                    post_config.get("cleanup_old_models", True) == True
+                ), "'cleanup_old_models' can not be False if 'keep_epochs' is specified"
                 post_config["cleanup_old_models"] = {"keep": keep_epochs}
             elif isinstance(post_config["cleanup_old_models"], dict):
+                assert (
+                    "keep" not in post_config["cleanup_old_models"]
+                ), "you can only provide either 'keep_epochs' or 'cleanup_old_models/keep', but not both"
                 post_config["cleanup_old_models"]["keep"] = keep_epochs
             else:
                 assert False, "invalid type of cleanup_old_models: %s" % type(

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -367,7 +367,7 @@ class ReturnnTrainingJob(Job):
         if returnn_config.post_config is not None:
             post_config.update(copy.deepcopy(returnn_config.post_config))
 
-        if "cleanup_old_models" in post_config and keep_epochs:
+        if keep_epochs:
             if isinstance(post_config["cleanup_old_models"], bool):
                 post_config["cleanup_old_models"] = {"keep": keep_epochs}
             elif isinstance(post_config["cleanup_old_models"], dict):

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -103,6 +103,8 @@ class ReturnnTrainingJob(Job):
             Note that this value is NOT HASHED, so that this number can be increased to continue the training.
         :param int save_interval: save a checkpoint each n-th epoch
         :param list[int]|set[int]|None keep_epochs: specify which checkpoints are kept, use None for the RETURNN default
+            This will also limit the available output checkpoints to those defined. If you want to specify the keep
+            behavior without this limitation, provide `cleanup_old_models/keep` in the post-config and use `None` here.
         :param int|float time_rqmt:
         :param int|float mem_rqmt:
         :param int cpu_rqmt:

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -411,12 +411,6 @@ class ReturnnTrainingJob(Job):
                 % key
             )
 
-        config_blacklisted_keys = ["cleanup_old_models"]
-        for key in config_blacklisted_keys:
-            assert returnn_config.config.get(key) is None, (
-                "please define %s only as parameter in the post_config" % key
-            )
-
     @classmethod
     def hash(cls, kwargs):
         d = {

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -250,16 +250,6 @@ class ReturnnTrainingJob(Job):
         lrf = self.returnn_config.get("learning_rate_file", "learning_rates")
         self._relink(lrf, self.out_learning_rates.get_path())
 
-        # cleanup
-        if hasattr(self, "keep_epochs"):
-            for e in os.scandir(self.out_model_dir.get_path()):
-                if e.is_file() and e.name.startswith("epoch."):
-                    s = e.name.split(".")
-                    idx = 2 if s[1] == "pretrain" else 1
-                    epoch = int(s[idx])
-                    if epoch not in self.keep_epochs:
-                        os.unlink(e.path)
-
     def plot(self):
         def EpochData(learningRate, error):
             return {"learning_rate": learningRate, "error": error}


### PR DESCRIPTION
I am not sure why this issue did not come up earlier, but the `keep_epochs` parameter of the job conflicted with any `cleanup_old_models` setting in the Returnn config.

With the new code, Returnn is responsible for cleaning, so that the fixed epochs can be combined with keeping the last and best (according to dev score) epochs. This allows e.g. to do recognition on fixed checkpoints but also automatically on the best checkpoints (as soon as all pipelines support this) without wasting a lot of file space.

One missing part is that currently the `self.out_checkpoints` are limited to the checkpoints defined in the `keep_epochs` list. Maybe we just drop this condition, and have "empty" outputs in case the model gets deleted. As long as the following jobs have an `update` check this is fine. 

This is the reason this is still a draft (and I am waiting for my tests to finish)
