### PR TITLE
added os.chmod to add reading permissions for all users

### DIFF
--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import struct
 import tempfile
-
+import stat
 from sisyphus import *
 
 Path = setup_path(__package__)
@@ -117,6 +117,7 @@ class MergeMixturesJob(rasr.RasrCommand, Job):
             util.partition_into_tree(self.mixtures_to_combine, self.combine_per_step),
         )
         shutil.move(mixtures, self.out_mixtures.get_path())
+        os.chmod(self.out_mixtures.get_path, stat.S_IROTH)
 
     def cleanup_before_run(self, cmd, retry, *args):
         log = args[2][12:]

--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -8,9 +8,10 @@ __all__ = [
 import logging
 import os
 import shutil
+import stat
 import struct
 import tempfile
-import stat
+
 from sisyphus import *
 
 Path = setup_path(__package__)

--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -117,7 +117,9 @@ class MergeMixturesJob(rasr.RasrCommand, Job):
             util.partition_into_tree(self.mixtures_to_combine, self.combine_per_step),
         )
         shutil.move(mixtures, self.out_mixtures.get_path())
-        os.chmod(self.out_mixtures.get_path, stat.S_IROTH)
+
+        update_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IROTH | stat.S_IRGRP
+        os.chmod(self.out_mixtures.get_path(), update_mode)
 
     def cleanup_before_run(self, cmd, retry, *args):
         log = args[2][12:]


### PR DESCRIPTION
Added a `os.chmod` call after `shutil.move` to add reading permissions for all users. Previously it sometimes occurred that users did not have any permission on the am.mix file created by the MexgeMixturesJob.