### PR TITLE
fixed whitelisting of CorpusToTxtJob

### DIFF
--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -133,7 +133,9 @@ class CorpusToTxtJob(Job):
 
         with uopen(self.out_txt.get_path(), "wt") as f:
             for segment in c.segments():
-                if (not segments_whitelist) or (segment.fullname() in segments_whitelist):
+                if (not segments_whitelist) or (
+                    segment.fullname() in segments_whitelist
+                ):
                     f.write(segment.orth + "\n")
 
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -133,7 +133,7 @@ class CorpusToTxtJob(Job):
 
         with uopen(self.out_txt.get_path(), "wt") as f:
             for segment in c.segments():
-                if not segments_whitelist or segment.fullname in segments_whitelist:
+                if (not segments_whitelist) or (segment.fullname() in segments_whitelist):
                     f.write(segment.orth + "\n")
 
 


### PR DESCRIPTION
`segments.fullname()` is a function not an attribute, thus this check always failed. Additionally added brackets for readability. 