### PR TITLE
fixed whitelisting of CorpusReplaceOrthFromTxtJob

### DIFF
--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -168,7 +168,9 @@ class CorpusReplaceOrthFromTxtJob(Job):
                 segments_whitelist = set(
                     l.strip() for l in f.readlines() if len(l.strip()) > 0
                 )
-            segment_iterator = filter(lambda s: s.fullname() in segments_whitelist, c.segments())
+            segment_iterator = filter(
+                lambda s: s.fullname() in segments_whitelist, c.segments()
+            )
         else:
             segment_iterator = c.segments()
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -168,7 +168,7 @@ class CorpusReplaceOrthFromTxtJob(Job):
                 segments_whitelist = set(
                     l.strip() for l in f.readlines() if len(l.strip()) > 0
                 )
-            segment_iterator = filter(lambda s: s in segments_whitelist, c.segments())
+            segment_iterator = filter(lambda s: s.fullname() in segments_whitelist, c.segments())
         else:
             segment_iterator = c.segments()
 


### PR DESCRIPTION
Similar to #216 check was done against the segment object not the name.