### PR TITLE
New Job to replace orth from other corpus

### DIFF
--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -1,8 +1,9 @@
 __all__ = [
-    "CorpusToStmJob",
-    "CorpusToTxtJob",
-    "CorpusReplaceOrthFromTxtJob",
     "CorpusReplaceOrthFromReferenceCorpus",
+    "CorpusReplaceOrthFromTxtJob",
+    "CorpusToStmJob",
+    "CorpusToTextDictJob",
+    "CorpusToTxtJob",
 ]
 
 import gzip
@@ -15,6 +16,94 @@ from i6_core.lib import corpus
 from i6_core.util import uopen
 
 Path = setup_path(__package__)
+
+
+class CorpusReplaceOrthFromReferenceCorpus(Job):
+    """
+    Copies the orth tag from one corpus to another through matching segment names.
+    """
+
+    def __init__(self, bliss_corpus, reference_bliss_corpus):
+        """
+        :param bliss_corpus: Corpus in which the orth tag is to be replaced
+        :param reference_bliss_corpus: Corpus from which the orth tag replacement is taken
+        """
+        self.bliss_corpus = bliss_corpus
+        self.reference_bliss_corpus = reference_bliss_corpus
+
+        self.out_corpus = self.output_path("corpus.xml.gz")
+
+    def tasks(self):
+        yield Task("run", mini_task=True)
+
+    def run(self):
+        orth_c = corpus.Corpus()
+        orth_c.load(tk.uncached_path(self.reference_bliss_corpus))
+
+        orths = {}
+        for r in orth_c.all_recordings():
+            for i in range(len(r.segments)):
+                orth = r.segments[i].orth
+                tag = r.segments[i].fullname()
+                orths[tag] = orth
+
+        c = corpus.Corpus()
+        c.load(tk.uncached_path(self.bliss_corpus))
+
+        for r in c.all_recordings():
+            for i in range(len(r.segments)):
+                tag = r.segments[i].fullname()
+                orth = orths[tag]
+                r.segments[i].orth = orth
+
+        c.dump(tk.uncached_path(self.out_corpus))
+
+
+class CorpusReplaceOrthFromTxtJob(Job):
+    """
+    Merge raw text back into a bliss corpus
+    """
+
+    def __init__(self, bliss_corpus, text_file, segment_file=None):
+        """
+        :param Path bliss_corpus: Bliss corpus
+        :param Path text_file: a raw or gzipped text file
+        :param Path|None: only replace the segments as specified in the segment file
+        """
+        self.bliss_corpus = bliss_corpus
+        self.text_file = text_file
+        self.segment_file = segment_file
+
+        self.out_corpus = self.output_path("corpus.xml.gz")
+
+    def tasks(self):
+        yield Task("run", mini_task=True)
+
+    def run(self):
+        c = corpus.Corpus()
+        c.load(self.bliss_corpus.get_path())
+
+        if self.segment_file:
+            with uopen(tk.uncached_path(self.segment_file), "rt") as f:
+                segments_whitelist = set(
+                    l.strip() for l in f.readlines() if len(l.strip()) > 0
+                )
+            segment_iterator = filter(
+                lambda s: s.fullname() in segments_whitelist, c.segments()
+            )
+        else:
+            segment_iterator = c.segments()
+
+        with uopen(self.text_file, "rt") as f:
+            for segment, line in itertools.zip_longest(segment_iterator, f):
+                assert (
+                    segment is not None
+                ), "there were more text file lines than segments"
+                assert line is not None, "there were less text file lines than segments"
+                assert len(line) > 0
+                segment.orth = line.strip()
+
+        c.dump(self.out_corpus.get_path())
 
 
 class CorpusToStmJob(Job):
@@ -101,96 +190,6 @@ class CorpusToStmJob(Job):
                 out.write(';; LABEL "%s" "%s" "%s"\n' % tag)
 
 
-class CorpusToTxtJob(Job):
-    """
-    Extract orth from a Bliss corpus and store as raw txt or gzipped txt
-    """
-
-    def __init__(self, bliss_corpus, segment_file=None, gzip=False):
-        """
-
-        :param Path bliss_corpus: Bliss corpus
-        :param Path segment_file: segment file
-        :param bool gzip: gzip the output text file
-        """
-        self.set_vis_name("Extract TXT from Corpus")
-
-        self.bliss_corpus = bliss_corpus
-        self.gzip = gzip
-        self.segment_file = segment_file
-
-        self.out_txt = self.output_path("corpus.txt" + (".gz" if gzip else ""))
-
-    def tasks(self):
-        yield Task("run", mini_task=True)
-
-    def run(self):
-        c = corpus.Corpus()
-        c.load(self.bliss_corpus.get_path())
-
-        if self.segment_file:
-            with uopen(self.segment_file, "rt") as f:
-                segments_whitelist = set(
-                    l.strip() for l in f.readlines() if len(l.strip()) > 0
-                )
-        else:
-            segments_whitelist = None
-
-        with uopen(self.out_txt.get_path(), "wt") as f:
-            for segment in c.segments():
-                if (not segments_whitelist) or (
-                    segment.fullname() in segments_whitelist
-                ):
-                    f.write(segment.orth + "\n")
-
-
-class CorpusReplaceOrthFromTxtJob(Job):
-    """
-    Merge raw text back into a bliss corpus
-    """
-
-    def __init__(self, bliss_corpus, text_file, segment_file=None):
-        """
-        :param Path bliss_corpus: Bliss corpus
-        :param Path text_file: a raw or gzipped text file
-        :param Path|None: only replace the segments as specified in the segment file
-        """
-        self.bliss_corpus = bliss_corpus
-        self.text_file = text_file
-        self.segment_file = segment_file
-
-        self.out_corpus = self.output_path("corpus.xml.gz")
-
-    def tasks(self):
-        yield Task("run", mini_task=True)
-
-    def run(self):
-        c = corpus.Corpus()
-        c.load(self.bliss_corpus.get_path())
-
-        if self.segment_file:
-            with uopen(tk.uncached_path(self.segment_file), "rt") as f:
-                segments_whitelist = set(
-                    l.strip() for l in f.readlines() if len(l.strip()) > 0
-                )
-            segment_iterator = filter(
-                lambda s: s.fullname() in segments_whitelist, c.segments()
-            )
-        else:
-            segment_iterator = c.segments()
-
-        with uopen(self.text_file, "rt") as f:
-            for segment, line in itertools.zip_longest(segment_iterator, f):
-                assert (
-                    segment is not None
-                ), "there were more text file lines than segments"
-                assert line is not None, "there were less text file lines than segments"
-                assert len(line) > 0
-                segment.orth = line.strip()
-
-        c.dump(self.out_corpus.get_path())
-
-
 class CorpusToTextDictJob(Job):
     """
     Extract the Text from a Bliss corpus to fit a "{key: text}" structure (e.g. for RETURNN)
@@ -241,42 +240,44 @@ class CorpusToTextDictJob(Job):
             f.write(dictionary_string)
 
 
-class CorpusReplaceOrthFromReferenceCorpus(Job):
+class CorpusToTxtJob(Job):
     """
-    Copies the orth tag from one corpus to another through matching segment names.
+    Extract orth from a Bliss corpus and store as raw txt or gzipped txt
     """
 
-    def __init__(self, bliss_corpus, reference_bliss_corpus):
+    def __init__(self, bliss_corpus, segment_file=None, gzip=False):
         """
-        :param bliss_corpus: Corpus in which the orth tag is to be replaced
-        :param reference_bliss_corpus: Corpus from which the orth tag replacement is taken
+
+        :param Path bliss_corpus: Bliss corpus
+        :param Path segment_file: segment file
+        :param bool gzip: gzip the output text file
         """
+        self.set_vis_name("Extract TXT from Corpus")
+
         self.bliss_corpus = bliss_corpus
-        self.reference_bliss_corpus = reference_bliss_corpus
+        self.gzip = gzip
+        self.segment_file = segment_file
 
-        self.out_corpus = self.output_path("corpus.xml.gz")
+        self.out_txt = self.output_path("corpus.txt" + (".gz" if gzip else ""))
 
     def tasks(self):
         yield Task("run", mini_task=True)
 
     def run(self):
-        orth_c = corpus.Corpus()
-        orth_c.load(tk.uncached_path(self.reference_bliss_corpus))
-
-        orths = {}
-        for r in orth_c.all_recordings():
-            for i in range(len(r.segments)):
-                orth = r.segments[i].orth
-                tag = r.segments[i].fullname()
-                orths[tag] = orth
-
         c = corpus.Corpus()
-        c.load(tk.uncached_path(self.bliss_corpus))
+        c.load(self.bliss_corpus.get_path())
 
-        for r in c.all_recordings():
-            for i in range(len(r.segments)):
-                tag = r.segments[i].fullname()
-                orth = orths[tag]
-                r.segments[i].orth = orth
+        if self.segment_file:
+            with uopen(self.segment_file, "rt") as f:
+                segments_whitelist = set(
+                    l.strip() for l in f.readlines() if len(l.strip()) > 0
+                )
+        else:
+            segments_whitelist = None
 
-        c.dump(tk.uncached_path(self.out_corpus))
+        with uopen(self.out_txt.get_path(), "wt") as f:
+            for segment in c.segments():
+                if (not segments_whitelist) or (
+                    segment.fullname() in segments_whitelist
+                ):
+                    f.write(segment.orth + "\n")

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -53,7 +53,7 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
         for r in c.all_recordings():
             for i in range(len(r.segments)):
                 tag = r.segments[i].fullname()
-                assert tag in orths.keys(), "Segment not found in Reference corpus"
+               assert tag in orths.keys(), "Segment %s not found in reference corpus" % s
                 orth = orths[tag]
                 r.segments[i].orth = orth
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -85,7 +85,7 @@ class CorpusReplaceOrthFromTxtJob(Job):
         c.load(self.bliss_corpus.get_path())
 
         if self.segment_file:
-            with uopen(tk.uncached_path(self.segment_file), "rt") as f:
+            with uopen(self.segment_file.get_path(), "rt") as f:
                 segments_whitelist = set(
                     l.strip() for l in f.readlines() if len(l.strip()) > 0
                 )

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -2,7 +2,7 @@ __all__ = [
     "CorpusToStmJob",
     "CorpusToTxtJob",
     "CorpusReplaceOrthFromTxtJob",
-    "CorpusReplaceOrthFromTag",
+    "CorpusReplaceOrthFromReferenceCorpus",
 ]
 
 import gzip

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -1,4 +1,9 @@
-__all__ = ["CorpusToStmJob", "CorpusToTxtJob", "CorpusReplaceOrthFromTxtJob", "CorpusReplaceOrthFromTag"]
+__all__ = [
+    "CorpusToStmJob",
+    "CorpusToTxtJob",
+    "CorpusReplaceOrthFromTxtJob",
+    "CorpusReplaceOrthFromTag",
+]
 
 import gzip
 import itertools
@@ -237,42 +242,42 @@ class CorpusToTextDictJob(Job):
 
 
 class CorpusReplaceOrthFromReferenceCorpus(Job):
-  """
-  Copies the orth tag from one corpus to another through matching segment names.
-  Only works for single segment recordings so far.
-  """
-
-  def __init__(self, bliss_corpus, reference_bliss_corpus):
     """
-    :param bliss_corpus: Corpus in which the orth tag is to be replaced
-    :param reference_bliss_corpus: Corpus from which the orth tag replacement is taken
+    Copies the orth tag from one corpus to another through matching segment names.
+    Only works for single segment recordings so far.
     """
-    self.bliss_corpus = bliss_corpus
-    self.reference_bliss_corpus = reference_bliss_corpus
 
-    self.out_corpus = self.output_path("corpus.xml.gz")
+    def __init__(self, bliss_corpus, reference_bliss_corpus):
+        """
+        :param bliss_corpus: Corpus in which the orth tag is to be replaced
+        :param reference_bliss_corpus: Corpus from which the orth tag replacement is taken
+        """
+        self.bliss_corpus = bliss_corpus
+        self.reference_bliss_corpus = reference_bliss_corpus
 
-  def tasks(self):
-    yield Task('run', mini_task=True)
+        self.out_corpus = self.output_path("corpus.xml.gz")
 
-  def run(self):
-    orth_c = corpus.Corpus()
-    orth_c.load(tk.uncached_path(self.reference_bliss_corpus))
+    def tasks(self):
+        yield Task("run", mini_task=True)
 
-    orths = {}
-    for r in orth_c.all_recordings():
-      assert len(r.segments) == 1, "needs to be a single segment recording"
-      orth = r.segments[0].orth
-      tag = r.segments[0].name
-      orths[tag] = orth
+    def run(self):
+        orth_c = corpus.Corpus()
+        orth_c.load(tk.uncached_path(self.reference_bliss_corpus))
 
-    c = corpus.Corpus()
-    c.load(tk.uncached_path(self.bliss_corpus))
+        orths = {}
+        for r in orth_c.all_recordings():
+            assert len(r.segments) == 1, "needs to be a single segment recording"
+            orth = r.segments[0].orth
+            tag = r.segments[0].name
+            orths[tag] = orth
 
-    for r in c.all_recordings():
-      assert len(r.segments) == 1, "needs to be a single segment recording"
-      tag = r.segments[0].name
-      orth = orths[tag]
-      r.segments[0].orth = orth
+        c = corpus.Corpus()
+        c.load(tk.uncached_path(self.bliss_corpus))
 
-    c.dump(tk.uncached_path(self.out_corpus))
+        for r in c.all_recordings():
+            assert len(r.segments) == 1, "needs to be a single segment recording"
+            tag = r.segments[0].name
+            orth = orths[tag]
+            r.segments[0].orth = orth
+
+        c.dump(tk.uncached_path(self.out_corpus))

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -38,7 +38,7 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
 
     def run(self):
         orth_c = corpus.Corpus()
-        orth_c.load(tk.uncached_path(self.reference_bliss_corpus))
+        orth_c.load(self.reference_bliss_corpus.get_path())
 
         orths = {}
         for r in orth_c.all_recordings():
@@ -48,15 +48,16 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
                 orths[tag] = orth
 
         c = corpus.Corpus()
-        c.load(tk.uncached_path(self.bliss_corpus))
+        c.load(self.bliss_corpus.get_path())
 
         for r in c.all_recordings():
             for i in range(len(r.segments)):
                 tag = r.segments[i].fullname()
+                assert tag in orths.keys(), "Segment not found in Reference corpus"
                 orth = orths[tag]
                 r.segments[i].orth = orth
 
-        c.dump(tk.uncached_path(self.out_corpus))
+        c.dump(self.out_corpus.get_path())
 
 
 class CorpusReplaceOrthFromTxtJob(Job):

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -53,7 +53,9 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
         for r in c.all_recordings():
             for i in range(len(r.segments)):
                 tag = r.segments[i].fullname()
-                assert tag in orths.keys(), "Segment %s not found in reference corpus" % s
+                assert tag in orths.keys(), (
+                    "Segment %s not found in reference corpus" % s
+                )
                 orth = orths[tag]
                 r.segments[i].orth = orth
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -267,7 +267,7 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
         for r in orth_c.all_recordings():
             for i in range(len(r.segments)):
                 orth = r.segments[i].orth
-                tag = r.segments[i].name
+                tag = r.segments[i].fullname()
                 orths[tag] = orth
 
         c = corpus.Corpus()
@@ -275,7 +275,7 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
 
         for r in c.all_recordings():
             for i in range(len(r.segments)):
-                tag = r.segments[i].name
+                tag = r.segments[i].fullname()
                 orth = orths[tag]
                 r.segments[i].orth = orth
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -53,7 +53,7 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
         for r in c.all_recordings():
             for i in range(len(r.segments)):
                 tag = r.segments[i].fullname()
-               assert tag in orths.keys(), "Segment %s not found in reference corpus" % s
+                assert tag in orths.keys(), "Segment %s not found in reference corpus" % s
                 orth = orths[tag]
                 r.segments[i].orth = orth
 

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -244,7 +244,6 @@ class CorpusToTextDictJob(Job):
 class CorpusReplaceOrthFromReferenceCorpus(Job):
     """
     Copies the orth tag from one corpus to another through matching segment names.
-    Only works for single segment recordings so far.
     """
 
     def __init__(self, bliss_corpus, reference_bliss_corpus):
@@ -266,18 +265,18 @@ class CorpusReplaceOrthFromReferenceCorpus(Job):
 
         orths = {}
         for r in orth_c.all_recordings():
-            assert len(r.segments) == 1, "needs to be a single segment recording"
-            orth = r.segments[0].orth
-            tag = r.segments[0].name
-            orths[tag] = orth
+            for i in range(len(r.segments)):
+                orth = r.segments[i].orth
+                tag = r.segments[i].name
+                orths[tag] = orth
 
         c = corpus.Corpus()
         c.load(tk.uncached_path(self.bliss_corpus))
 
         for r in c.all_recordings():
-            assert len(r.segments) == 1, "needs to be a single segment recording"
-            tag = r.segments[0].name
-            orth = orths[tag]
-            r.segments[0].orth = orth
+            for i in range(len(r.segments)):
+                tag = r.segments[i].name
+                orth = orths[tag]
+                r.segments[i].orth = orth
 
         c.dump(tk.uncached_path(self.out_corpus))

--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -68,7 +68,7 @@ class CorpusReplaceOrthFromTxtJob(Job):
         """
         :param Path bliss_corpus: Bliss corpus
         :param Path text_file: a raw or gzipped text file
-        :param Path|None: only replace the segments as specified in the segment file
+        :param Path|None segment_file: only replace the segments as specified in the segment file
         """
         self.bliss_corpus = bliss_corpus
         self.text_file = text_file


### PR DESCRIPTION
Moved (and refactored) job from an old setup that takes two corpora and replaces the orth tags for sequences from one with orth tags from the other one, matched on the sequence key in contrast to ordering.