### PR TITLE
support dicts in ReturnnDumpHDFJob

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -11,7 +11,6 @@ import string
 import textwrap
 
 from sisyphus import *
-from sisyphus.delayed_ops import DelayedBase
 from sisyphus.hash import sis_hash_helper
 
 from i6_core.util import instanciate_delayed

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -14,29 +14,10 @@ from sisyphus import *
 from sisyphus.delayed_ops import DelayedBase
 from sisyphus.hash import sis_hash_helper
 
+from i6_core.util import instanciate_delayed
+
 Path = setup_path(__package__)
 Variable = tk.Variable
-
-
-def instanciate_delayed(o):
-    """
-    Recursively traverses a structure and calls .get() on all
-    existing Delayed Operations, especially Variables in the structure
-
-    :param Any o: nested structure that may contain DelayedBase objects
-    :return:
-    """
-    if isinstance(o, DelayedBase):
-        o = o.get()
-    elif isinstance(o, list):
-        for k in range(len(o)):
-            o[k] = instanciate_delayed(o[k])
-    elif isinstance(o, tuple):
-        o = tuple(instanciate_delayed(e) for e in o)
-    elif isinstance(o, dict):
-        for k in o:
-            o[k] = instanciate_delayed(o[k])
-    return o
 
 
 class CodeWrapper:

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -33,7 +33,7 @@ class ReturnnDumpHDFJob(Job):
     ):
         """
 
-        :param dict|Path|str data: a string defining a RETURNN dataset
+        :param dict|Path|str data: a dict, path, or string defining a RETURNN dataset
         :param start_seq: first sequence to dump in the dataset
         :param end_seq: last sequence to dump in the dataset
         :param int epoch: epoch to dump

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -5,7 +5,7 @@ import subprocess as sp
 
 from .rasr_training import ReturnnRasrTrainingJob
 import i6_core.rasr as rasr
-from i6_core.util import relink
+from i6_core.util import relink, instanciate_delayed
 
 from sisyphus import *
 
@@ -72,7 +72,7 @@ class ReturnnDumpHDFJob(Job):
     def run(self):
         data = self.data
         if isinstance(data, dict):
-            resolve_sis_paths_in_dict(data)
+            instanciate_delayed(data)
             data = str(data)
         elif isinstance(data, tk.Path):
             data = data.get_path()

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -33,7 +33,7 @@ class ReturnnDumpHDFJob(Job):
     ):
         """
 
-        :param str data: a string defining a RETURNN dataset
+        :param dict|Path|str data: a string defining a RETURNN dataset
         :param start_seq: first sequence to dump in the dataset
         :param end_seq: last sequence to dump in the dataset
         :param int epoch: epoch to dump
@@ -71,10 +71,11 @@ class ReturnnDumpHDFJob(Job):
 
     def run(self):
         data = self.data
-        if isinstance(data, str):
+        if isinstance(data, dict):
+            resolve_sis_paths_in_dict(data)
             data = str(data)
-        else:
-            data = tk.uncached_path(data)
+        elif isinstance(data, tk.Path):
+            data = data.get_path()
 
         args = [
             tk.uncached_path(self.returnn_python_exe),

--- a/util.py
+++ b/util.py
@@ -282,6 +282,12 @@ def check_file_sha256_checksum(filename, reference_checksum):
 
 
 def resolve_sis_paths_in_dict(dictionary):
+    """
+    Iterates through a (nested) dict and replaces all Path instances 
+    with the respective file paths. Only to be used in the Worker.
+    
+    :param dict dictionary: a dict containing Path objects to be replaced
+    """
     for k, v in dictionary.items():
         if isinstance(v, dict):
             resolve_sis_paths_in_dict(v)

--- a/util.py
+++ b/util.py
@@ -279,3 +279,10 @@ def check_file_sha256_checksum(filename, reference_checksum):
     :param str filename: a single file to be checked
     """
     assert compute_file_sha256_checksum(filename) == reference_checksum
+
+def resolve_sis_paths_in_dict(dictionary):
+    for k, v in dictionary.items():
+        if isinstance(v, dict):
+            resolve_sis_paths_in_dict(v)
+        elif isinstance(v, tk.Path):
+            dictionary[k] = v.get_path()

--- a/util.py
+++ b/util.py
@@ -280,6 +280,7 @@ def check_file_sha256_checksum(filename, reference_checksum):
     """
     assert compute_file_sha256_checksum(filename) == reference_checksum
 
+
 def resolve_sis_paths_in_dict(dictionary):
     for k, v in dictionary.items():
         if isinstance(v, dict):

--- a/util.py
+++ b/util.py
@@ -283,9 +283,9 @@ def check_file_sha256_checksum(filename, reference_checksum):
 
 def resolve_sis_paths_in_dict(dictionary):
     """
-    Iterates through a (nested) dict and replaces all Path instances 
+    Iterates through a (nested) dict and replaces all Path instances
     with the respective file paths. Only to be used in the Worker.
-    
+
     :param dict dictionary: a dict containing Path objects to be replaced
     """
     for k, v in dictionary.items():

--- a/util.py
+++ b/util.py
@@ -7,6 +7,7 @@ import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
 from sisyphus import *
+from sisyphus.delayed_ops import DelayedBase
 
 Path = setup_path(__package__)
 Variable = tk.Variable


### PR DESCRIPTION
the docstring suggested that data should only be of type `str` while an inline comment suggested `dict|Path|str`.
the old implementation definitively worked for strings - although 
```
if isinstance(data, str):
    data = str(data)
```
seemed kinda weird to me - and otherwise assumed Path - again, I am unsure how a path defines a dataset. 

Anyway, now support for dicts is added while - I think - the handling of str and Path is unchanged.

Kudos to Jan Engler for the `resolve_sis_paths_in_dict` function. I think it might be useful in many places and therefore added it under util.