### PR TITLE
add WriteRasrConfigJob

### DIFF
--- a/rasr/config.py
+++ b/rasr/config.py
@@ -344,7 +344,7 @@ class StringWrapper:
         return self.string
 
 
-class WriteRasrConfigJob(Job, RasrCommand):
+class WriteRasrConfigJob(RasrCommand, Job):
     """
     Write a RasrConfig object into a .config file
     """

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -11,6 +11,7 @@ import itertools as it
 from sisyphus import Job, Task
 
 from i6_core import util
+from i6_core.rasr.command import RasrCommand
 
 
 class RasrConfig:
@@ -343,7 +344,7 @@ class StringWrapper:
         return self.string
 
 
-class WriteRasrConfigJob(Job):
+class WriteRasrConfigJob(Job, RasrCommand):
     """
     Write a RasrConfig object into a .config file
     """
@@ -362,9 +363,11 @@ class WriteRasrConfigJob(Job):
         yield Task("run", mini_task=True)
 
     def run(self):
-        self.config._update(self.post_config)
-        with util.uopen(self.out_config, "wt") as f:
-            f.write(repr(self.config))
+        self.write_config(
+            config=self.config,
+            post_config=self.post_config,
+            filename=self.out_config.get_path(),
+        )
 
     @classmethod
     def hash(cls, kwargs):

--- a/tests/job_tests/rasr/test_config.py
+++ b/tests/job_tests/rasr/test_config.py
@@ -1,0 +1,36 @@
+import os
+from sisyphus import Path
+import tempfile
+
+from i6_core.rasr.config import RasrConfig, WriteRasrConfigJob
+
+
+TEST_CONFIG = """[*]
+dummy-variable       = 42
+other-dummy-variable = 24
+"""
+
+
+def test_write_rasr_config():
+    """
+    This test can be used to test the writing of different variable types into a rasr config
+    and check for correct serialization. Only dummy example for now.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rasr_config = RasrConfig()
+        rasr_config["*"].dummy_variable = 42
+
+        post_rasr_config = RasrConfig()
+        post_rasr_config["*"].other_dummy_variable = 24
+
+        write_rasr_config_job = WriteRasrConfigJob(rasr_config, post_rasr_config)
+        write_rasr_config_job.out_config = Path(os.path.join(tmpdir, "rasr.config"))
+        write_rasr_config_job.run()
+
+        with open(write_rasr_config_job.out_config) as config_file:
+            for i, (source_line, reference_line) in enumerate(
+                zip(config_file.readlines(), TEST_CONFIG.split("\n"))
+            ):
+                assert (
+                    source_line.strip() == reference_line.strip()
+                ), "line mismatch in %i:\n%s vs %s" % (i, source_line, reference_line)


### PR DESCRIPTION
There are some use cases where you just want to dump a config (e.g. to link them in a RETURNN training job with some custom rasr loss without ugly local job hacks)