### PR TITLE
add set_executables for crp and add requried helper

### DIFF
--- a/rasr/command.py
+++ b/rasr/command.py
@@ -88,7 +88,8 @@ fi
         :param str exe_name:
         :param str rasr_root:
         :param str rasr_arch:
-        :return:
+        :return: path to a rasr binary with the default path pattern inside the repsoitory
+        :rtype: str
         """
         exe = os.path.join(
             rasr_root, "arch", rasr_arch, "%s.%s" % (exe_name, rasr_arch)

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -83,15 +83,27 @@ fi
             os.chmod(filename, 0o755)
 
     @classmethod
+    def get_rasr_exe(cls, exe_name, rasr_root, rasr_arch):
+        """
+        :param str exe_name:
+        :param str rasr_root:
+        :param str rasr_arch:
+        :return:
+        """
+        exe = os.path.join(
+            rasr_root, "arch", rasr_arch, "%s.%s" % (exe_name, rasr_arch)
+        )
+        return exe
+
+    @classmethod
     def default_exe(cls, exe_name):
         """
+        Extract executable path from the global sisyphus settings
+
         :param str exe_name:
         :rtype: str
         """
-        exe = os.path.join(
-            gs.RASR_ROOT, "arch", gs.RASR_ARCH, "%s.%s" % (exe_name, gs.RASR_ARCH)
-        )
-        return exe
+        return cls.get_rasr_exe(exe_name, gs.RASR_ROOT, gs.RASR_ARCH)
 
     @classmethod
     def select_exe(cls, specific_exe, default_exe_name):

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -67,7 +67,7 @@ class CommonRasrParameters:
 
         Is (not yet) compatible with tk.Path inputs
 
-        :param str rasr_root: director path of a RASR repository
+        :param str rasr_root: path of a directory containing the RASR repository
         :param str rasr_arch: RASR architecture specifier
         """
         self.acoustic_model_trainer_exe = RasrCommand.get_rasr_exe(

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -1,5 +1,6 @@
 from sisyphus.http_server import object_to_html
 
+from .command import RasrCommand
 from .config import RasrConfig
 
 
@@ -59,6 +60,41 @@ class CommonRasrParameters:
 
     def html(self):
         return object_to_html(self.__dict__)
+
+    def set_executables(self, rasr_root, rasr_arch="linux-x86_64-standard"):
+        """
+        Set all executables to a single RASR path
+
+        Is (not yet) compatible with tk.Path inputs
+
+        :param str rasr_root: director path of a RASR repository
+        :param str rasr_arch: RASR architecture specifier
+        """
+        self.acoustic_model_trainer_exe = RasrCommand.get_rasr_exe(
+            "acoustic-model-trainer", rasr_root, rasr_arch
+        )
+        self.allophone_tool_exe = RasrCommand.get_rasr_exe(
+            "allophone-tool", rasr_root, rasr_arch
+        )
+        self.costa_exe = RasrCommand.get_rasr_exe("costa", rasr_root, rasr_arch)
+        self.feature_extraction_exe = RasrCommand.get_rasr_exe(
+            "feature-extraction", rasr_root, rasr_arch
+        )
+        self.feature_statistics_exe = RasrCommand.get_rasr_exe(
+            "feature-statistics", rasr_root, rasr_arch
+        )
+        self.flf_tool_exe = RasrCommand.get_rasr_exe("flf-tool", rasr_root, rasr_arch)
+        self.kws_tool_exe = None  # does not exist
+        self.lattice_processor_exe = RasrCommand.get_rasr_exe(
+            "lattice-processor", rasr_root, rasr_arch
+        )
+        self.lm_util_exe = RasrCommand.get_rasr_exe("lm-util", rasr_root, rasr_arch)
+        self.nn_trainer_exe = RasrCommand.get_rasr_exe(
+            "nn-trainer", rasr_root, rasr_arch
+        )
+        self.speech_recognizer_exe = RasrCommand.get_rasr_exe(
+            "speech-rcognizer", rasr_root, rasr_arch
+        )
 
 
 def crp_add_default_output(


### PR DESCRIPTION
I wanted to have a nicer way of setting a custom RASR (custom in the sense as being different to the one in the settings.py). I am not sure that this is all that is needed, but it is a good start.