### PR TITLE
AlignSplitAccumulateSequence: Alias and Score Reports

### DIFF
--- a/meta/mm_sequence.py
+++ b/meta/mm_sequence.py
@@ -207,14 +207,12 @@ class AlignSplitAccumulateSequence:
         """
         :return: report .txt file path containing the alignment scores in order of the job sequence
         """
-        if self.report_job is not None:
-            return self.report_job.out_report
-
-        logs = []
-        for job, log in zip(self.all_jobs, self.all_logs):
-            if isinstance(job, AlignmentJob):
-                logs.append(log)
-        self.report_job = AMScoresFromAlignmentLogJob(logs)
+        if self.report_job is None:
+            logs = []
+            for job, log in zip(self.all_jobs, self.all_logs):
+                if isinstance(job, AlignmentJob):
+                    logs.append(log)
+            self.report_job = AMScoresFromAlignmentLogJob(logs)
         return self.report_job.out_report
 
 

--- a/meta/mm_sequence.py
+++ b/meta/mm_sequence.py
@@ -201,6 +201,17 @@ class AlignSplitAccumulateSequence:
             else:
                 raise ValueError("Unknown action: %s" % action)
 
+    def get_alignment_score_report(self):
+        """
+        :return: report .txt file path containing the alignment scores in order of the job sequence
+        """
+
+        logs = []
+        for job, log in zip(self.all_jobs, self.all_logs):
+            if isinstance(job, AlignmentJob):
+                logs.append(log)
+        return AMScoresFromAlignmentLogJob(logs).out_report
+
 
 def align_then_split_and_accumulate_sequence(
     num_align, num_accumulate, mark_accumulate=True, mark_align=True

--- a/meta/mm_sequence.py
+++ b/meta/mm_sequence.py
@@ -43,9 +43,9 @@ class AlignSplitAccumulateSequence:
         """
         :param rasr.crp.CommonRasrParameters crp:
         :param list[str] action_sequence: a list actions which can be:
-            - split
-            - accumulate
-            - align
+            - "split"
+            - "accumulate"
+            - "align"
 
             An action can be written as e.g. "align!" to indicate that this alignment output
             should not be marked as output, meaning it will stored in `self.selected_alignment`

--- a/meta/mm_sequence.py
+++ b/meta/mm_sequence.py
@@ -113,6 +113,8 @@ class AlignSplitAccumulateSequence:
         self.selected_mixtures = []
         self.selected_alignments = []
 
+        self.report_job = None  # type: AMScoresFromAlignmentLogJob|None
+
         current_alignment = initial_alignment
         current_mixtures = initial_mixtures
 
@@ -205,12 +207,15 @@ class AlignSplitAccumulateSequence:
         """
         :return: report .txt file path containing the alignment scores in order of the job sequence
         """
+        if self.report_job is not None:
+            return self.report_job.out_report
 
         logs = []
         for job, log in zip(self.all_jobs, self.all_logs):
             if isinstance(job, AlignmentJob):
                 logs.append(log)
-        return AMScoresFromAlignmentLogJob(logs).out_report
+        self.report_job = AMScoresFromAlignmentLogJob(logs)
+        return self.report_job.out_report
 
 
 def align_then_split_and_accumulate_sequence(

--- a/meta/mm_sequence.py
+++ b/meta/mm_sequence.py
@@ -48,7 +48,7 @@ class AlignSplitAccumulateSequence:
             - "align"
 
             An action can be written as e.g. "align!" to indicate that this alignment output
-            should not be marked as output, meaning it will stored in `self.selected_alignment`
+            should be marked as output, meaning it will stored in `self.selected_alignment`
             and get the keep_value for "selected" (or the Sisyphus default if not defined)
         :param FlowNetwork feature_flow:
         :param initial_mixtures:


### PR DESCRIPTION
I now often came across the problem that I did not know at which stage my current GMM training is, or which steps were already removed when running the cleaner. With this PR, a monophone Alignment job could get the name e.g.:
`alias/experiments/librispeech/librispeech_100_gmm/gmm_tina/train/train-clean-100_mono_action_sequence/action_28_align`

I also added a function which computes a report file from which you can directly read the convergence rate of the GMM training using the `AMScoresFromAlignmentLogJob` (to be honest I never knew it exists). Then even if all job get cleaned (which one should definitely do) you still can read the final alignment scores.

The rest is some added documentation (which is definitely still incomplete).