### PR TITLE
remove space from speaker name

### DIFF
--- a/corpus/convert.py
+++ b/corpus/convert.py
@@ -182,7 +182,7 @@ class CorpusToStmJob(Job):
                     % (
                         segment.recording.name,
                         segment_track,
-                        speaker_name,
+                        "_".join(speaker_name.split()),
                         segment.start,
                         segment.end,
                         ",".join(tag_map[segment.fullname()]),


### PR DESCRIPTION
If there are spaces in the speaker name, then they screw up the column counting in the stm file.

I propose to replace all spaces and related characters by an underscore.