### PR TITLE
check for empty prons in G2POutputToBlissLexiconJob

### DIFF
--- a/g2p/convert.py
+++ b/g2p/convert.py
@@ -114,7 +114,8 @@ class G2POutputToBlissLexiconJob(Job):
             g2p_lexicon.lemmata = iv_lexicon.lemmata
 
         for orth, prons in oov_words.items():
-            lemma = lexicon.Lemma(orth=[orth], phon=prons)
-            g2p_lexicon.add_lemma(lemma)
+            if len(prons) > 0:
+                lemma = lexicon.Lemma(orth=[orth], phon=prons)
+                g2p_lexicon.add_lemma(lemma)
 
         write_xml(self.out_oov_lexicon.get_path(), g2p_lexicon.to_xml())


### PR DESCRIPTION
We already check if one specific line does not contain a pronunciation. 

But if an orthography never has a finite pronunciation, then still a lemma is added

```
<lemma>
    <orth> some_example </orth>
</lemma>
```

I propose to only add lemmata with at least one pronunciation.

Question: should this always happen or should it be a controllable parameter?