### PR TITLE
ReturnnConfig: parse delayed ops in prolog/epilog

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -229,7 +229,7 @@ class ReturnnConfig:
         if isinstance(code, str):
             return code
         if isinstance(code, DelayedBase):
-            return code.get()
+            return self.__parse_python(code.get())
         if isinstance(code, (tuple, list)):
             return "\n".join(self.__parse_python(c) for c in code)
         if isinstance(code, dict):


### PR DESCRIPTION
In one of my `ReturnConfig`'s prolog, I have a `DelayedFormat` object. Currently, this cannot be parsed, therefore I'd like to add it.