### PR TITLE
fix check for existing lm.image

### DIFF
--- a/lm/lm_image.py
+++ b/lm/lm_image.py
@@ -75,7 +75,7 @@ class CreateLmImageJob(rasr.RasrCommand, Job):
 
         assert config.lm_util.lm.type == "ARPA"
 
-        if post_config.lm_util.lm.image:
+        if "image" in post_config.lm_util.lm:
             logging.warning(
                 "The LM image already exists, but a new one will be recreated."
             )


### PR DESCRIPTION
as one can see in 
https://github.com/rwth-i6/i6_core/blob/234feddb16d600fe618cfdcce4152f89eab06252/rasr/config.py#L143-L147
and
https://github.com/rwth-i6/i6_core/blob/234feddb16d600fe618cfdcce4152f89eab06252/rasr/config.py#L105-L113

the call `post_config.lm_util.lm.image` will create an empty `RasrConfig` if no image exists. Thus, this statement always evaluates to `True`.

This fix correctly evaluates to `False` if no image exists.