### PR TITLE
remove setdefault sort_dicts for PrettyPrinter kwargs

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -8,6 +8,7 @@ import os
 import pickle
 import pprint
 import string
+import sys
 import textwrap
 
 from sisyphus import *
@@ -121,6 +122,8 @@ class ReturnnConfig:
                 self.python_epilog_hash = python_epilog
         self.sort_config = sort_config
         self.pprint_kwargs = pprint_kwargs or {}
+        if sys.version_info[:2] >= (3, 8):
+            self.pprint_kwargs.setdefault("sort_dicts", sort_config)
         self.black_formatting = black_formatting
 
     def get(self, key, default=None):

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -121,7 +121,6 @@ class ReturnnConfig:
                 self.python_epilog_hash = python_epilog
         self.sort_config = sort_config
         self.pprint_kwargs = pprint_kwargs or {}
-        self.pprint_kwargs.setdefault("sort_dicts", sort_config)
         self.black_formatting = black_formatting
 
     def get(self, key, default=None):


### PR DESCRIPTION
In python < 3.8 the `pprint.PrettyPrinter` class does not accept the keyword arg `sort_dicts`.
(c.f. https://docs.python.org/3.7/library/pprint.html)

If needed, this option can still be set via the `pprint_kwargs` manually.