### PR TITLE
Extend ReturnnConfig for returnn_common usage

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -22,6 +22,10 @@ Variable = tk.Variable
 
 
 class CodeWrapper:
+    """
+    Can be used to insert direct "code" (not as quoted string) into the config dict
+    """
+
     def __init__(self, code):
         self.code = code
 
@@ -41,6 +45,7 @@ class ReturnnConfig:
     PYTHON_CODE = textwrap.dedent(
         """\
         #!rnn.py
+
         ${SUPPORT_CODE}
 
         ${PROLOG}

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -95,7 +95,8 @@ class ReturnnConfig:
         :param dict post_config: dictionary of the RETURNN config variables that are not hashed
         :param None|dict[int, str|dict[str, Any]] staged_network_dict:
             dictionary of network dictionaries or
-            returnn_common generated strings (as str variable from get_ext_net_dict_py_code_str),
+            any string that defines a network with `network = ...`
+            (e.g. the return variable of get_ext_net_dict_py_code_str() from returnn_common),
             indexed by the desired starting epoch of the network stage.
             By enabling this, an additional "networks" folder will be created next to the config location.
         :param None|str|Callable|Class|tuple|list|dict python_prolog: str or structure containing str/callables/classes


### PR DESCRIPTION
Extends the ReturnnConfig to allow using returnn_common both as "within manager" and "within job".
 For "within manager" the resulting py_str can be added as network stage, while otherwise we just pass elements to prolog/epilog. In this case we neither have "network" in the dict nor set `staged_network_dict`, so we have to remove the assert.

Also contains some additional docstrings and formatting.

related to: https://github.com/rwth-i6/i6_experiments/issues/63