### PR TITLE
fix word_list naming inconsistency

### DIFF
--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -73,11 +73,13 @@ class ApplyG2PModelJob(Job):
             yield Task("filter", mini_task=True)
 
     def split_word_list(self):
+        num_digits = len(str(self.concurrent))
         sp.check_call(
             [
                 "split",
                 f"--number=l/{self.concurrent}",
                 "--numeric-suffixes=1",
+                f"--suffix-length={num_digits}",
                 self.word_list.get_path(),
                 "words.",
             ]


### PR DESCRIPTION
The default suffix-length of `split` (according to man page) is 2. 
I tried running the job with concurrent=1 and the word_list file that was generated was named "words.01". Then the subsequent Task "run" couldn't find the correct file, because "words.1" was expected.

This fixes the naming inconsistency.