### PR TITLE
refactor code formatting for mfcc, gammatone, energy

### DIFF
--- a/features/energy.py
+++ b/features/energy.py
@@ -1,13 +1,17 @@
 __all__ = ["EnergyJob", "energy_flow"]
 
 import copy
+from typing import Any, Dict, Optional
 
-from .common import *
-from .extraction import *
-import i6_core.rasr as rasr
+from i6_core.features.common import fft_flow, samples_flow
+from i6_core.features.extraction import FeatureExtractionJob
+from i6_core.rasr import FlowNetwork
+from i6_core.rasr.crp import CommonRasrParameters
 
 
-def EnergyJob(crp, energy_options=None, **kwargs):
+def EnergyJob(
+    crp: CommonRasrParameters, energy_options: Optional[Dict[str, Any]] = None, **kwargs
+) -> FeatureExtractionJob:
     if energy_options is None:
         energy_options = {}
     else:
@@ -29,12 +33,23 @@ def EnergyJob(crp, energy_options=None, **kwargs):
 
 
 def energy_flow(
-    without_samples=False,
-    samples_options={},
-    fft_options={},
-    normalization_type="divide-by-mean",
-):
-    net = rasr.FlowNetwork()
+    without_samples: bool = False,
+    samples_options: Optional[Dict[str, Any]] = None,
+    fft_options: Optional[Dict[str, Any]] = None,
+    normalization_type: str = "divide-by-mean",
+) -> FlowNetwork:
+    """
+    :param without_samples:
+    :param samples_options: arguments to :func:`~features.common.sample_flow`
+    :param fft_options: arguments to :func:`~features.common.fft_flow`
+    :param str normalization_type:
+    """
+    if samples_options is None:
+        samples_options = {}
+    if fft_options is None:
+        fft_options = {}
+
+    net = FlowNetwork()
 
     if without_samples:
         net.add_input("samples")

--- a/features/gammatone.py
+++ b/features/gammatone.py
@@ -36,7 +36,7 @@ def gammatone_flow(
     minfreq: int = 100,
     maxfreq: int = 7500,
     channels: int = 68,
-    warp_freqbreak=None,
+    warp_freqbreak: Optional[int] = None,
     tempint_type: str = "hanning",
     tempint_shift: float = 0.01,
     tempint_length: float = 0.025,

--- a/features/gammatone.py
+++ b/features/gammatone.py
@@ -1,13 +1,17 @@
 __all__ = ["GammatoneJob", "gammatone_flow"]
 
 import copy
+from typing import Any, Dict, Optional
 
-from .common import *
-from .extraction import *
-import i6_core.rasr as rasr
+from i6_core.features.common import samples_flow
+from i6_core.features.extraction import FeatureExtractionJob
+from i6_core.rasr import FlowNetwork
+from i6_core.rasr.crp import CommonRasrParameters
 
 
-def GammatoneJob(crp, gt_options=None, **kwargs):
+def GammatoneJob(
+    crp: CommonRasrParameters, gt_options: Optional[Dict[str, Any]] = None, **kwargs
+) -> FeatureExtractionJob:
     if gt_options is None:
         gt_options = {}
     else:
@@ -29,27 +33,53 @@ def GammatoneJob(crp, gt_options=None, **kwargs):
 
 
 def gammatone_flow(
-    minfreq=100,
-    maxfreq=7500,
-    channels=68,
+    minfreq: int = 100,
+    maxfreq: int = 7500,
+    channels: int = 68,
     warp_freqbreak=None,
-    tempint_type="hanning",
-    tempint_shift=0.01,
-    tempint_length=0.025,
-    flush_before_gap=True,
-    do_specint=True,
-    specint_type="hanning",
-    specint_shift=4,
-    specint_length=9,
-    normalize=True,
-    preemphasis=True,
-    legacy_scaling=False,
-    without_samples=False,
-    samples_options={},
-    normalization_options={},
-    add_features_output=False,
-):
-    net = rasr.FlowNetwork()
+    tempint_type: str = "hanning",
+    tempint_shift: float = 0.01,
+    tempint_length: float = 0.025,
+    flush_before_gap: bool = True,
+    do_specint: bool = True,
+    specint_type: str = "hanning",
+    specint_shift: int = 4,
+    specint_length: int = 9,
+    normalize: bool = True,
+    preemphasis: bool = True,
+    legacy_scaling: bool = False,
+    without_samples: bool = False,
+    samples_options: Optional[Dict[str, Any]] = None,
+    normalization_options: Optional[Dict[str, Any]] = None,
+    add_features_output: bool = False,
+) -> FlowNetwork:
+    """
+    :param minfreq:
+    :param maxfreq:
+    :param channels:
+    :param warp_freqbreak:
+    :param tempint_type:
+    :param tempint_shift:
+    :param tempint_length:
+    :param flush_before_gap:
+    :param do_specint:
+    :param specint_type:
+    :param specint_shift:
+    :param specint_length:
+    :param normalize:
+    :param preemphasis:
+    :param legacy_scaling:
+    :param without_samples:
+    :param samples_options: arguments to :func:`~features.common.sample_flow`
+    :param normalization_options:
+    :param add_features_output:
+    """
+    if normalization_options is None:
+        normalization_options = {}
+    if samples_options is None:
+        samples_options = {}
+
+    net = FlowNetwork()
     if add_features_output:
         net.add_output("features")
 

--- a/features/mfcc.py
+++ b/features/mfcc.py
@@ -1,17 +1,20 @@
 __all__ = ["MfccJob", "mfcc_flow"]
 
 import copy
+from typing import Any, Dict, Optional
 
-from .common import *
-from .extraction import *
-import i6_core.rasr as rasr
+from i6_core.features.common import cepstrum_flow, fft_flow, samples_flow
+from i6_core.features.extraction import FeatureExtractionJob
+from i6_core.rasr import FlowNetwork
+from i6_core.rasr.crp import CommonRasrParameters
 
 
-def MfccJob(crp, mfcc_options=None, **kwargs):
+def MfccJob(
+    crp: CommonRasrParameters, mfcc_options: Optional[Dict[str, Any]] = None, **kwargs
+) -> FeatureExtractionJob:
     """
-    :param rasr.crp.CommonRasrParameters crp:
-    :param dict[str] mfcc_options:
-    :rtype: FeatureExtractionJob
+    :param crp:
+    :param mfcc_options: Nested parameters for :func:`mfcc_flow`
     """
     if mfcc_options is None:
         mfcc_options = {}
@@ -31,25 +34,26 @@ def MfccJob(crp, mfcc_options=None, **kwargs):
 
 
 def mfcc_flow(
-    warping_function="mel",
-    filter_width=268.258,
-    normalize=True,
-    normalization_options=None,
-    without_samples=False,
-    samples_options=None,
-    fft_options=None,
-    cepstrum_options=None,
-    add_features_output=False,
-):
+    warping_function: str = "mel",
+    filter_width: float = 268.258,
+    normalize: bool = True,
+    normalization_options: Optional[Dict[str, Any]] = None,
+    without_samples: bool = False,
+    samples_options: Optional[Dict[str, Any]] = None,
+    fft_options: Optional[Dict[str, Any]] = None,
+    cepstrum_options: Optional[Dict[str, Any]] = None,
+    add_features_output: bool = False,
+) -> FlowNetwork:
     """
-    :param warping_function str:
-    :param filter_width float:
-    :param normalize bool: whether to add or not a normalization layer
-    :param without_samples bool:
-    :param samples_options dict: arguments to :func:`~features.common.sample_flow`
-    :param fft_options dict: arguments to :func:`~features.common.fft_flow`
-    :param cepstrum_options dict: arguments to :func:`~features.common.cepstrum_flow`
-    :param add_features_output bool: Add the output port "features" when normalize is True. This should be set to True,
+    :param warping_function:
+    :param filter_width:
+    :param normalize: whether to add or not a normalization layer
+    :param normalization_options:
+    :param without_samples:
+    :param samples_options: arguments to :func:`~features.common.sample_flow`
+    :param fft_options: arguments to :func:`~features.common.fft_flow`
+    :param cepstrum_options: arguments to :func:`~features.common.cepstrum_flow`
+    :param add_features_output: Add the output port "features" when normalize is True. This should be set to True,
         default is False to not break existing hash.
     """
     if normalization_options is None:
@@ -64,7 +68,7 @@ def mfcc_flow(
     if normalize and "normalize" not in cepstrum_options:
         cepstrum_options["normalize"] = False
 
-    net = rasr.FlowNetwork()
+    net = FlowNetwork()
 
     if without_samples:
         net.add_input("samples")


### PR DESCRIPTION
Some style updates and incomplete docstrings. I did not update all files because of time issues.

The only relevant change is that `energy_flow` now correctly handles `samples_options` and `fft_options`.