### PR TITLE
actually delete old lm image if found

### DIFF
--- a/lm/lm_image.py
+++ b/lm/lm_image.py
@@ -79,6 +79,7 @@ class CreateLmImageJob(rasr.RasrCommand, Job):
             logging.warning(
                 "The LM image already exists, but a new one will be recreated."
             )
+            del post_config.lm_util.lm.image
 
         config.lm_util.action = "load-lm"
         config.lm_util.lm.image = "lm.image"


### PR DESCRIPTION
If an LM image is found in post_config, a warning is emitted, but only `config.lm_util.lm.image` is overwritten and post_config stays untouched.
Later, when writing the config file, the image in post_config overrides the image in config and no new image is created. This causes the Job to fail.

This PR deletes the image like it was announced in the warning.