### PR TITLE
sctk_binary_path variable in Hub5ScoreJob

### DIFF
--- a/recognition/scoring.py
+++ b/recognition/scoring.py
@@ -203,6 +203,7 @@ class ScliteJob(Job):
 
 class Hub5ScoreJob(Job):
     __sis_hash_exclude__ = {"sctk_binary_path": None}
+
     def __init__(
         self,
         ref: Union[tk.Path, str],
@@ -243,13 +244,14 @@ class Hub5ScoreJob(Job):
         yield Task("run", mini_task=True)
 
     def run(self, move_files=True):
-
         sctk_path = ""
         if self.sctk_binary_path is not None:
             sctk_path = self.sctk_binary_path.get_path()
         elif hasattr(gs, "SCTK_PATH"):
             sctk_path = gs.SCTK_PATH
-        hubscr_path = os.path.join(sctk_path, "hubscr.pl") # evaluates to just "hubscr.pl" if sctk_path is empty
+        hubscr_path = os.path.join(
+            sctk_path, "hubscr.pl"
+        )  # evaluates to just "hubscr.pl" if sctk_path is empty
 
         sctk_opt = ["-p", sctk_path] if sctk_path else []
 

--- a/recognition/scoring.py
+++ b/recognition/scoring.py
@@ -211,6 +211,12 @@ class Hub5ScoreJob(Job):
         hyp: tk.Path,
         sctk_binary_path: Optional[tk.Path] = None,
     ):
+        """
+        :param ref: reference stm text file
+        :param glm: text file containing mapping rules for scoring
+        :param hyp: hypothesis ctm text file
+        :param sctk_binary_path: set an explicit binary path.
+        """
         self.set_vis_name("HubScore")
 
         self.glm = glm

--- a/recognition/scoring.py
+++ b/recognition/scoring.py
@@ -206,9 +206,9 @@ class Hub5ScoreJob(Job):
 
     def __init__(
         self,
-        ref: Union[tk.Path, str],
-        glm: Union[tk.Path, str],
-        hyp: Union[tk.Path, str],
+        ref: tk.Path,
+        glm: tk.Path,
+        hyp: tk.Path,
         sctk_binary_path: Optional[tk.Path] = None,
     ):
         self.set_vis_name("HubScore")

--- a/recognition/scoring.py
+++ b/recognition/scoring.py
@@ -12,7 +12,7 @@ import subprocess as sp
 import tempfile
 import collections
 import re
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from sisyphus import *
 from i6_core.lib.corpus import *

--- a/recognition/scoring.py
+++ b/recognition/scoring.py
@@ -263,20 +263,20 @@ class Hub5ScoreJob(Job):
 
         ref = self.ref
         try:
-            ref = shutil.copy(tk.uncached_path(ref), ".")
+            ref = shutil.copy(ref.get_path(), ".")
         except shutil.SameFileError:
             pass
 
         hyp = self.hyp
         try:
-            hyp = shutil.copy(tk.uncached_path(hyp), ".")
+            hyp = shutil.copy(hyp.get_path(), ".")
         except shutil.SameFileError:
             pass
 
         sp.check_call(
             [hubscr_path, "-V", "-l", "english", "-h", "hub5"]
             + sctk_opt
-            + ["-g", tk.uncached_path(self.glm), "-r", ref, hyp]
+            + ["-g", self.glm.get_path(), "-r", ref, hyp]
         )
 
         if move_files:  # run as real job


### PR DESCRIPTION
The use of binary path variables in the sisyphus.global_settings might become deprecated in the future (as discussed in #254). This is a slight change of the Hub5ScoreJob similar to the ScliteJob in this direction. Moreover, some type annotations have been added to the __init__ signature.