### PR TITLE
ForwardJob allow network without Checkpoint/Params

### DIFF
--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -149,7 +149,7 @@ def get_returnn_length_hdfs(
         returnn_root=returnn_root,
         hdf_outputs=hdf_outputs,
         mem_rqmt=mem_rqmt,
-        time_rqmt=time_rqmt
+        time_rqmt=time_rqmt,
     )
     if job_alias is not None:
         forward_job.add_alias(job_alias)

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -1,15 +1,14 @@
-__all__ = ["ExtractDatasetMeanStddevJob", "get_returnn_length_hdfs"]
+__all__ = ["ExtractDatasetMeanStddevJob"]
 
 from sisyphus import *
 
 import os
 import shutil
 import subprocess
-from typing import Any, Dict, List, Optional
 
 import numpy
 
-from i6_core.returnn import ReturnnConfig, ReturnnForwardJob, Checkpoint
+from i6_core.returnn import ReturnnConfig
 from i6_core.util import create_executable
 
 
@@ -91,71 +90,3 @@ class ExtractDatasetMeanStddevJob(Job):
 
             self.out_mean.set(total_mean)
             self.out_std_dev.set(numpy.sqrt(total_var))
-
-
-def get_returnn_length_hdfs(
-    dataset_dict: Dict[str, Any],
-    extern_data: Dict[str, Any],
-    dataset_keys: List,
-    returnn_exe: tk.Path,
-    returnn_root: tk.Path,
-    job_alias: Optional[str] = None,
-    mem_rqmt: float = 4,
-    time_rqmt: float = 4,
-) -> Dict[str, tk.Path]:
-    """
-    Uses returnn to extract the length of sequences in the datasets after feature extraction, returns a separate hdf
-    file per dataset key
-    :param dataset_dict: RETURNN config dict for dataset
-    :param extern_data: extern data dict matching the dataset
-    :param dataset_keys: keys of the datastreams
-    :param returnn_exe:
-    :param returnn_root:
-    :param job_alias: full alias of the forward job
-    :param mem_rqmt: job memory requirement in GB
-    :param time_rqmt: job time requirement in hours
-    :return:
-    """
-    post_config = {"use_tensorflow": True}
-    config = {
-        "eval": dataset_dict,
-        "network": {
-            "output": {
-                "class": "length",
-                "axis": "T",
-                "from": f"data:{dataset_keys[0]}",
-            },
-        },
-        "extern_data": extern_data,
-        "max_seqs": 50,
-    }
-    for idx, key in enumerate(dataset_keys[1:]):
-        config["network"][f"length_{idx}"] = {
-            "class": "length",
-            "axis": "T",
-            "from": f"data:{key}",
-        }
-        config["network"][f"dump_{idx}"] = {
-            "class": "hdf_dump",
-            "filename": f"{key}.hdf",
-            "from": f"length_data_{idx}",
-        }
-
-    hdf_outputs = [k + ".hdf" for k in dataset_keys[1:]]
-    config = ReturnnConfig(config=config, post_config=post_config)
-    forward_job = ReturnnForwardJob(
-        model_checkpoint=None,
-        returnn_config=config,
-        returnn_python_exe=returnn_exe,
-        returnn_root=returnn_root,
-        hdf_outputs=hdf_outputs,
-        mem_rqmt=mem_rqmt,
-        time_rqmt=time_rqmt,
-    )
-    if job_alias is not None:
-        forward_job.add_alias(job_alias)
-    # remove .hdf extension and map default output to first dataset key
-    hdf_dict = {k[:-4]: v for k, v in forward_job.out_hdf_files.items()}
-    hdf_dict[dataset_keys[0]] = hdf_dict["output"]
-    del hdf_dict["output"]
-    return hdf_dict

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -8,7 +8,7 @@ import subprocess
 
 import numpy
 
-from i6_core.returnn import ReturnnConfig
+from i6_core.returnn.config import ReturnnConfig
 from i6_core.util import create_executable
 
 

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -100,6 +100,8 @@ def get_returnn_length_hdfs(
     returnn_exe: tk.Path,
     returnn_root: tk.Path,
     job_alias: Optional[str] = None,
+    mem_rqmt: float = 4,
+    time_rqmt: float = 4,
 ) -> Dict[str, tk.Path]:
     """
     Uses returnn to extract the length of sequences in the datasets after feature extraction, returns a separate hdf
@@ -110,6 +112,8 @@ def get_returnn_length_hdfs(
     :param returnn_exe:
     :param returnn_root:
     :param job_alias: full alias of the forward job
+    :param mem_rqmt: job memory requirement in GB
+    :param time_rqmt: job time requirement in hours
     :return:
     """
     post_config = {"use_tensorflow": True}
@@ -144,6 +148,8 @@ def get_returnn_length_hdfs(
         returnn_python_exe=returnn_exe,
         returnn_root=returnn_root,
         hdf_outputs=hdf_outputs,
+        mem_rqmt=mem_rqmt,
+        time_rqmt=time_rqmt
     )
     if job_alias is not None:
         forward_job.add_alias(job_alias)

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -148,7 +148,7 @@ def get_returnn_length_hdfs(
     if job_alias is not None:
         forward_job.add_alias(job_alias)
     # remove .hdf extension and map default output to first dataset key
-    hdf_dict = {k[:-4]: v for k, v in forward_job.out_hdf_files}
+    hdf_dict = {k[:-4]: v for k, v in forward_job.out_hdf_files.items()}
     hdf_dict[dataset_keys[0]] = hdf_dict["output"]
     del hdf_dict["output"]
     return hdf_dict

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -5,7 +5,7 @@ from sisyphus import *
 import os
 import shutil
 import subprocess
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy
 
@@ -95,31 +95,60 @@ class ExtractDatasetMeanStddevJob(Job):
 
 def get_returnn_length_hdfs(
     dataset_dict: Dict[str, Any],
-    data_dim: int,
+    extern_data: Dict[str, Any],
     dataset_keys: List,
     returnn_exe: tk.Path,
     returnn_root: tk.Path,
-):
+    job_alias: Optional[str] = None,
+) -> Dict[str, tk.Path]:
+    """
+    Uses returnn to extract the length of sequences in the datasets after feature extraction, returns a separate hdf
+    file per dataset key
+    :param dataset_dict: RETURNN config dict for dataset
+    :param extern_data: extern data dict matching the dataset
+    :param dataset_keys: keys of the datastreams
+    :param returnn_exe:
+    :param returnn_root:
+    :param job_alias: full alias of the forward job
+    :return:
+    """
     post_config = {"use_tensorflow": True}
     config = {
         "eval": dataset_dict,
         "network": {
-            "output": {"class": "length", "axis": "T", "from": f"data:{dataset_keys[0]}"},
-            f"length_{idx}": {"class": "length", "axis": "T", "from": f"data:{key}"} for idx, key in enumerate(dataset_keys)
-            f"dump_{idx}": {"class": "hdf_dump", "filename": f"{key}.hdf", "from": f"length_data_{idx}"} for idx, key in enumerate(dataset_keys)
+            "output": {
+                "class": "length",
+                "axis": "T",
+                "from": f"data:{dataset_keys[0]}",
+            },
         },
-        "extern_data": {data_key: {"available_for_inference": True, "dim": data_dim, "shape": (None, data_dim)}}
+        "extern_data": extern_data,
     }
-    for idx, key in enumerate(dataset_keys):
-        config["network"][f"length_{idx}"] = {"class": "length", "axis": "T", "from": f"data:{key}"}
-        config["network"][f"dump_{idx}"] = {"class": "hdf_dump", "filename": f"{key}.hdf", "from": f"length_data_{idx}"}
+    for idx, key in enumerate(dataset_keys[1:]):
+        config["network"][f"length_{idx}"] = {
+            "class": "length",
+            "axis": "T",
+            "from": f"data:{key}",
+        }
+        config["network"][f"dump_{idx}"] = {
+            "class": "hdf_dump",
+            "filename": f"{key}.hdf",
+            "from": f"length_data_{idx}",
+        }
 
+    hdf_outputs = [k + ".hdf" for k in dataset_keys]
     config = ReturnnConfig(config=config, post_config=post_config)
     forward_job = ReturnnForwardJob(
         model_checkpoint=None,
         returnn_config=config,
         returnn_python_exe=returnn_exe,
         returnn_root=returnn_root,
-        hdf_outputs=dataset_keys,
+        hdf_outputs=hdf_outputs,
     )
-    return forward_job.out_hdf_files
+    if job_alias is not None:
+        forward_job.add_alias(job_alias)
+    # remove .hdf extension and map default output to first dataset key
+    hdf_dict = {k[:-4]: v for k, v in forward_job.out_hdf_files}
+    hdf_dict[dataset_keys[0]] = hdf_dict["output"]
+    del hdf_dict["output"]
+    return hdf_dict

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -127,6 +127,7 @@ def get_returnn_length_hdfs(
             },
         },
         "extern_data": extern_data,
+        "max_seqs": 50
     }
     for idx, key in enumerate(dataset_keys[1:]):
         config["network"][f"length_{idx}"] = {

--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -1,4 +1,4 @@
-__all__ = ["ExtractDatasetMeanStddevJob"]
+__all__ = ["ExtractDatasetMeanStddevJob", "get_returnn_length_hdfs"]
 
 from sisyphus import *
 
@@ -127,7 +127,7 @@ def get_returnn_length_hdfs(
             },
         },
         "extern_data": extern_data,
-        "max_seqs": 50
+        "max_seqs": 50,
     }
     for idx, key in enumerate(dataset_keys[1:]):
         config["network"][f"length_{idx}"] = {
@@ -141,7 +141,7 @@ def get_returnn_length_hdfs(
             "from": f"length_data_{idx}",
         }
 
-    hdf_outputs = [k + ".hdf" for k in dataset_keys]
+    hdf_outputs = [k + ".hdf" for k in dataset_keys[1:]]
     config = ReturnnConfig(config=config, post_config=post_config)
     forward_job = ReturnnForwardJob(
         model_checkpoint=None,

--- a/returnn/forward.py
+++ b/returnn/forward.py
@@ -32,7 +32,7 @@ class ReturnnForwardJob(Job):
 
     def __init__(
         self,
-        model_checkpoint: Checkpoint,
+        model_checkpoint: Optional[Checkpoint],
         returnn_config: ReturnnConfig,
         returnn_python_exe: tk.Path,
         returnn_root: tk.Path,
@@ -47,7 +47,8 @@ class ReturnnForwardJob(Job):
     ):
         """
 
-        :param model_checkpoint: Checkpoint object pointing to a stored RETURNN Tensorflow model
+        :param model_checkpoint: Checkpoint object pointing to a stored RETURNN Tensorflow model or None if network has
+          no parameters
         :param returnn_config: RETURNN config object
         :param returnn_python_exe: path to the RETURNN executable (python binary or launch script)
         :param returnn_root: path to the RETURNN src folder
@@ -61,6 +62,8 @@ class ReturnnForwardJob(Job):
         :param cpu_rqmt: job cpu requirement
         """
         self.returnn_config = returnn_config
+        if model_checkpoint is None:
+            assert not eval_mode, "Eval requires a checkpoint"
         self.model_checkpoint = model_checkpoint
         self.returnn_python_exe = returnn_python_exe
         self.returnn_root = returnn_root
@@ -107,9 +110,10 @@ class ReturnnForwardJob(Job):
         util.create_executable("rnn.sh", cmd)
 
         # check here if model actually exists
-        assert os.path.exists(
-            self.model_checkpoint.index_path.get_path()
-        ), "Provided model does not exists: %s" % str(self.model_checkpoint)
+        if self.model_checkpoint is not None:
+            assert os.path.exists(
+                self.model_checkpoint.index_path.get_path()
+            ), "Provided model does not exists: %s" % str(self.model_checkpoint)
 
     def run(self):
         # run everything in a TempDir as writing HDFs can cause heavy load
@@ -141,7 +145,7 @@ class ReturnnForwardJob(Job):
     @classmethod
     def create_returnn_config(
         cls,
-        model_checkpoint: Checkpoint,
+        model_checkpoint: Optional[Checkpoint],
         returnn_config: ReturnnConfig,
         eval_mode: bool,
         log_verbosity: int,
@@ -166,10 +170,13 @@ class ReturnnForwardJob(Job):
 
         res = copy.deepcopy(returnn_config)
 
-        config = {
-            "load": model_checkpoint,
-            "task": "eval" if eval_mode else "forward",
-        }
+        if model_checkpoint is not None:
+            config = {
+                "load": model_checkpoint,
+                "task": "eval" if eval_mode else "forward",
+            }
+        else:
+            config = {"task": "forward", "allow_random_model_init": True}
 
         post_config = {
             "device": device,

--- a/returnn/forward.py
+++ b/returnn/forward.py
@@ -48,7 +48,7 @@ class ReturnnForwardJob(Job):
         """
 
         :param model_checkpoint: Checkpoint object pointing to a stored RETURNN Tensorflow model or None if network has
-          no parameters
+          no parameters or should be randomly initialized
         :param returnn_config: RETURNN config object
         :param returnn_python_exe: path to the RETURNN executable (python binary or launch script)
         :param returnn_root: path to the RETURNN src folder


### PR DESCRIPTION
Helper to run returnn feature extraction dumping the sequence lengths into hdf files.
Not tested yet, thus draft PR.