### PR TITLE
adding option for returnn config as Path

### DIFF
--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -80,10 +80,16 @@ class CompileTFGraphJob(Job):
             yield Task("run", resume="run", mini_task=True)
 
     def run(self):
-        returnn_config_path = self.returnn_config
-        if isinstance(self.returnn_config, ReturnnConfig):
+        if isinstance(self.returnn_config, tk.Path):
+            returnn_config_path = self.returnn_config.get_path()
+            
+        elif isinstance(self.returnn_config, ReturnnConfig):
             returnn_config_path = "returnn.config"
             self.returnn_config.write(returnn_config_path)
+
+        else: returnn_config_path = self.returnn_config
+
+
 
         args = [
             tk.uncached_path(self.returnn_python_exe),
@@ -103,6 +109,7 @@ class CompileTFGraphJob(Job):
             args.append("--device=%s" % self.device)
         if self.summaries_tensor_name is not None:
             args.append("--summaries_tensor_name=%s" % self.summaries_tensor_name)
+
 
         util.create_executable("run.sh", args)
 

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -82,14 +82,13 @@ class CompileTFGraphJob(Job):
     def run(self):
         if isinstance(self.returnn_config, tk.Path):
             returnn_config_path = self.returnn_config.get_path()
-            
+
         elif isinstance(self.returnn_config, ReturnnConfig):
             returnn_config_path = "returnn.config"
             self.returnn_config.write(returnn_config_path)
 
-        else: returnn_config_path = self.returnn_config
-
-
+        else:
+            returnn_config_path = self.returnn_config
 
         args = [
             tk.uncached_path(self.returnn_python_exe),
@@ -109,7 +108,6 @@ class CompileTFGraphJob(Job):
             args.append("--device=%s" % self.device)
         if self.summaries_tensor_name is not None:
             args.append("--summaries_tensor_name=%s" % self.summaries_tensor_name)
-
 
         util.create_executable("run.sh", args)
 


### PR DESCRIPTION
In case `self.returnn_config` is a `Path` this code will crash. Added the option by considering the three allowed cases.