### PR TITLE
FilterLexicon: keep lemma if synt/tok matches.

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -42,12 +42,26 @@ class LexiconToWordListJob(Job):
 
 
 class FilterLexiconByWordListJob(Job):
-    def __init__(self, bliss_lexicon, word_list, case_sensitive=False):
+    """
+    Filter lemmata to given word list.
+    Warning: case_sensitive parameter does the opposite. Kept for backwards-compatibility.
+    """
+
+    def __init__(
+        self, bliss_lexicon, word_list, case_sensitive=False, check_synt_tok=False
+    ):
+        """
+        :param tk.Path bliss_lexicon: lexicon file to be handeled
+        :param tk.Path word_list: filter lexicon by this word list
+        :param bool case_sensitive: filter lemmata case-sensitive. Warning: parameter does the opposite.
+        :param bool check_synt_tok: keep also lemmata where the syntactic token matches word_list
+        """
         self.set_vis_name("Filter Lexicon by Word List")
 
         self.bliss_lexicon = bliss_lexicon
         self.word_list = word_list
         self.case_sensitive = case_sensitive
+        self.check_synt_tok = check_synt_tok
 
         self.out_bliss_lexicon = self.output_path(
             os.path.basename(tk.uncached_path(bliss_lexicon)), cached=True
@@ -72,6 +86,10 @@ class FilterLexiconByWordListJob(Job):
                 transform(orth.text) in words
                 or "special" in lemma.attrib
                 or (orth.text is not None and orth.text.startswith("["))
+                or (
+                    self.check_synt_tok
+                    and transform(lemma.find("./synt/tok").text) in words
+                )
                 for orth in lemma.findall("orth")
             ):
                 root.append(lemma)

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -47,6 +47,8 @@ class FilterLexiconByWordListJob(Job):
     Warning: case_sensitive parameter does the opposite. Kept for backwards-compatibility.
     """
 
+    __sis_hash_exclude__ = {"check_synt_tok": False}
+
     def __init__(
         self, bliss_lexicon, word_list, case_sensitive=False, check_synt_tok=False
     ):
@@ -86,11 +88,15 @@ class FilterLexiconByWordListJob(Job):
                 transform(orth.text) in words
                 or "special" in lemma.attrib
                 or (orth.text is not None and orth.text.startswith("["))
-                or (
-                    self.check_synt_tok
-                    and transform(lemma.find("./synt/tok").text) in words
-                )
                 for orth in lemma.findall("orth")
+            ) or (
+                self.check_synt_tok
+                and all(
+                    [
+                        transform(tok.text) in words
+                        for tok in lemma.findall("./synt/tok")
+                    ]
+                )
             ):
                 root.append(lemma)
 


### PR DESCRIPTION
We don't want to filter out lemmata that match the synt tok from a wordlist/lm-vocabulary list.
Kept this as an option for backward compatibility and set the default to false.

And added doc string information.
Especially the part about where the case-sensitive parameter logic is inverse.