### PR TITLE
Fix Start, End and Epoch for ReturnnDumpHDFJob

### DIFF
--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -89,11 +89,11 @@ class ReturnnDumpHDFJob(Job):
             tmp_hdf_file,
         ]
         if self.start_seq is not None:
-            args.append(f"--start_seq {self.start_seq}")
+            args += ["--start_seq", f"{self.start_seq}"]
         if self.end_seq is not None:
-            args.append(f"--end_seq {self.end_seq}")
+            args += ["--end_seq", f"{self.end_seq}"]
         if self.epoch is not None:
-            args.append(f"--epoch {self.epoch}")
+            args += ["--epoch", f"{self.epoch}"]
 
         sp.check_call(args)
         shutil.move(tmp_hdf_file, self.out_hdf.get_path())


### PR DESCRIPTION
fix for #302 
Basically somehow the spacing did not work, this way it works.
The ints have to be passed as strings, otherwise there is a TypeError when constructing the command.