### PR TITLE
BlissChangeEncodingJob: allow no recover duration

### DIFF
--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -22,9 +22,9 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         fixed_bitrate=None,
         force_num_channels=None,
         select_channels=None,
-        recover_duration=None,
         ffmpeg_binary=None,
         hash_binary=False,
+        recover_duration=None,
     ):
         """
         For all parameter holds that "None" means to use the ffmpeg defaults, which depend on the input file
@@ -41,12 +41,13 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         :param tuple(str)|None select_channels: tuple of (channel_layout, channel_name), see `ffmpeg -layouts`
             this is useful if the new encoding might have an effect on the duration, or if no duration was specified
             in the source corpus
-        :param bool|None recover_duration: This will open all files with "soundfile" and extract the length information.
-            There might be minimal differences when converting the encoding, so only set this to `False` if you're
-            willing to accept this risk.
         :param Path|str|None ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
         :param bool hash_binary: In some cases it might be required to work with a specific ffmpeg version,
                                  in which case the binary needs to be hashed
+        :param bool|None recover_duration: This will open all files with "soundfile" and extract the length information.
+            There might be minimal differences when converting the encoding, so only set this to `False` if you're
+            willing to accept this risk. `None` (default) means that the duration is recovered if either `output_format`
+            or `codec` is specified because this might possibly lead to duration mismatches.
         """
         ffmpeg_options = []
 


### PR DESCRIPTION
When I recently used this job to change the encoding for our switchboard corpus using the `BlissChangeEncodingJob`, it didn't work because `recover_duration` was automatically set to `True`. However, this requires that each recording in the corpus contains only a single segment which is not the case for switchboard. When checking selected converted files, the duration was exactly the same. I therefore propose to add an option to this job which allows disabling the duration recovering manually. A comment is added so users know about the risk of doing this.