### PR TITLE
Make rasr.FlowNetwork serialization deterministic.

### DIFF
--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -358,16 +358,15 @@ class FlowNetwork:
 
         for name in self.__compute_node_order():
             attr = self.nodes[name]
-            nstr = {"name": name}
-            for k, v in attr.items():
+            n = ET.SubElement(root, "node", {"name": name})
+
+            for k, v in sorted(attr.items()):
                 while isinstance(v, FlowAttribute):
                     v = v.get(self)
                 if type(v) == bool:
-                    nstr[k] = str(v).lower()
+                    n.attrib[k] = str(v).lower()
                 else:
-                    nstr[k] = str(v)
-
-            ET.SubElement(root, "node", nstr)
+                    n.attrib[k] = str(v)
 
             if name in links_by_target_node:
                 for link in links_by_target_node[name]:

--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -329,7 +329,7 @@ class FlowNetwork:
                 dependencies[to_node].add(from_node)
 
         while len(missing_nodes) > 0:
-            for n in missing_nodes:
+            for n in sorted(missing_nodes):
                 if all(dep in added_nodes for dep in dependencies[n]):
                     result.append(n)
                     added_nodes.add(n)
@@ -337,7 +337,8 @@ class FlowNetwork:
                     break
             else:
                 # no node added => contains loops => add one node regardless of dependencies
-                n = missing_nodes.pop()
+                n = list(sorted(missing_nodes))[0]
+                missing_nodes.remove(n)
                 result.append(n)
                 added_nodes.add(n)
 

--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -357,8 +357,9 @@ class FlowNetwork:
                 ET.SubElement(root, node, name=n)
 
         for name in self.__compute_node_order():
-            attr = self.nodes[name]
-            n = ET.SubElement(root, "node", {"name": name})
+            attr = dict(**self.nodes[name])
+            attr["name"] = name
+            n = ET.SubElement(root, "node", {})
 
             for k, v in sorted(attr.items()):
                 while isinstance(v, FlowAttribute):

--- a/tests/job_tests/rasr/test_flow.py
+++ b/tests/job_tests/rasr/test_flow.py
@@ -1,0 +1,39 @@
+import string
+
+from i6_core.rasr.flow import FlowNetwork
+
+
+def test_deterministic_flow_serialization():
+    """
+    Check if the RASR flow network is serialized in a deterministic way by
+    running multiple serializations of slightly different flow networks.
+    Serialization used to be non-deterministic over different python interpreter runs.
+    """
+
+    ref_net = """\
+<?xml version="1.0" ?>
+<network name="network">
+  <node name="{0}" filter="a"/>
+  <node name="{1}" filter="b"/>
+  <link from="{0}" to="{1}"/>
+  <node name="{2}" filter="c"/>
+  <link from="{0}" to="{2}"/>
+  <node name="{3}" filter="d"/>
+  <link from="{1}" to="{3}"/>
+  <link from="{2}" to="{3}"/>
+</network>
+"""
+
+    nets = []
+    for i in range(50):
+        net = FlowNetwork()
+        nets.append(net)
+        nodes = []
+        for n in "abcd":
+            nodes.append(net.add_node(n, n + str(i)))
+        net.link(nodes[0], nodes[1])
+        net.link(nodes[0], nodes[2])
+        net.link(nodes[1], nodes[3])
+        net.link(nodes[2], nodes[3])
+
+        assert str(net) == ref_net.format(*nodes), "Failed after %d iterations" % i

--- a/tests/job_tests/rasr/test_flow.py
+++ b/tests/job_tests/rasr/test_flow.py
@@ -13,12 +13,12 @@ def test_deterministic_flow_serialization():
     ref_net = """\
 <?xml version="1.0" ?>
 <network name="network">
-  <node name="{0}" filter="a"/>
-  <node name="{1}" filter="b"/>
+  <node filter="a" name="{0}"/>
+  <node filter="b" name="{1}"/>
   <link from="{0}" to="{1}"/>
-  <node name="{2}" filter="c"/>
+  <node filter="c" name="{2}"/>
   <link from="{0}" to="{2}"/>
-  <node name="{3}" filter="d"/>
+  <node filter="d" name="{3}"/>
   <link from="{1}" to="{3}"/>
   <link from="{2}" to="{3}"/>
 </network>


### PR DESCRIPTION
Serialization at the moment can differ between different runs of the python interpreter. This is somewhat inconvenient for AppTek as we have a workflow that packages models into a tar-ball and stores them under the hash of that archive. Having different hashes between different runs can result in different tar-balls for equivalent models.