### PR TITLE
CompileTFGraph add config as output

### DIFF
--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -91,6 +91,7 @@ class CompileTFGraphJob(Job):
 
         else:
             returnn_config_path = self.returnn_config
+            shutil.copy(self.returnn_config, self.out_returnn_config.get_path())
 
         args = [
             tk.uncached_path(self.returnn_python_exe),

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -70,6 +70,7 @@ class CompileTFGraphJob(Job):
         self.out_graph = self.output_path("graph.%s" % output_format)
         self.out_model_params = self.output_var("model_params.pickle", pickle=True)
         self.out_state_vars = self.output_var("state_vars.pickle", pickle=True)
+        self.out_returnn_config = self.output_path("returnn.config")
 
         self.rqmt = None
 
@@ -82,9 +83,10 @@ class CompileTFGraphJob(Job):
     def run(self):
         if isinstance(self.returnn_config, tk.Path):
             returnn_config_path = self.returnn_config.get_path()
+            shutil.copy(returnn_config_path, self.out_returnn_config.get_path())
 
         elif isinstance(self.returnn_config, ReturnnConfig):
-            returnn_config_path = "returnn.config"
+            returnn_config_path = self.out_returnn_config.get_path()
             self.returnn_config.write(returnn_config_path)
 
         else:


### PR DESCRIPTION
This is good for checking what you actually compiled, which is not visible otherwise if you use work folder cleaning.