### PR TITLE
Increase Merge time in MergeMixturesJob

### DIFF
--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -64,7 +64,7 @@ class MergeMixturesJob(rasr.RasrCommand, Job):
         self.out_merge_log_file = self.log_file_output_path("merge", crp, merge_count)
         self.out_mixtures = self.output_path("am.mix", cached=True)
 
-        self.merge_rqmt = {"time": max(merge_count / 25, 0.5), "cpu": 1, "mem": 1}
+        self.merge_rqmt = {"time": max(merge_count / 15, 0.5), "cpu": 1, "mem": 1}
 
     def tasks(self):
         yield Task("create_merge_mixtures_config", mini_task=True)


### PR DESCRIPTION
Some of my Jobs have been running out of time for the `merge_mixtures` task. If found they were ~75% completed so I gave a bit more time above that just to be sure.