### PR TITLE
ExtractDatasetMeanStddevJob, fix command args

### DIFF
--- a/returnn/dataset.py
+++ b/returnn/dataset.py
@@ -65,9 +65,13 @@ class ExtractDatasetMeanStddevJob(Job):
             tk.uncached_path(self.returnn_python_exe),
             os.path.join(tk.uncached_path(self.returnn_root), "tools/dump-dataset.py"),
             "returnn.config",
-            "--endseq -1",
+            "--endseq",
+            "-1",
+            "--type",
+            "null",
             "--stats",
-            "--dump_stats stats",
+            "--dump_stats",
+            "stats",
         ]
 
         create_executable("rnn.sh", command)


### PR DESCRIPTION
It only has worked before because `create_executable` does not do proper shell formatting (e.g. putting quotes around strings with spaces, escaping).

I also add `--type null` to cleanup the log output and speedup the generation.