### PR TITLE
ReturnnSearchJobV2, fix hash when output_gzip is enabled

### DIFF
--- a/returnn/search.py
+++ b/returnn/search.py
@@ -201,6 +201,8 @@ class ReturnnSearchJobV2(Job):
             "returnn_python_exe": kwargs["returnn_python_exe"],
             "returnn_root": kwargs["returnn_root"],
         }
+        if kwargs.get("output_gzip", False) is not False:
+            d["output_gzip"] = kwargs["output_gzip"]
         return super().hash(d)
 
 


### PR DESCRIPTION
Followup to #325. I forgot that we have a custom `hash` in this job.