### PR TITLE
add TASK parameter to flow in AdvancedTreeSearchJob

### DIFF
--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -226,6 +226,7 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
 
     def create_files(self):
         self.write_config(self.config, self.post_config, "recognition.config")
+        self.feature_flow.add_param("TASK")
         self.feature_flow.write_to_file("feature.flow")
         util.write_paths_to_file(
             self.out_lattice_bundle, self.out_single_lattice_caches.values()


### PR DESCRIPTION
It was found that the AdvancedTreeSearchJob is currently not adding the `TASK` parameter to the flow, thus crashing when the cache manager module is not existing in RASR. All other jobs (Alignment, Mixtures) are adding the parameter within the `create_files` Job-Task, so we also should do it here.