### PR TITLE
Idea to add a tmp dir option for all RasrCommand Jobs

### DIFF
--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -387,6 +387,7 @@ class EstimateMixturesJob(MergeMixturesJob):
         self.concurrent = crp.concurrent
 
         self._old_mixtures = old_mixtures
+        self.use_tmp_dir = True
 
         self.out_log_file = self.log_file_output_path("accumulate", crp, True)
 
@@ -425,7 +426,10 @@ class EstimateMixturesJob(MergeMixturesJob):
 
     def accumulate(self, task_id):
         self.run_script(
-            task_id, self.out_log_file[task_id], "./accumulate.sh", use_tmp_dir=True
+            task_id,
+            self.out_log_file[task_id],
+            "./accumulate.sh",
+            use_tmp_dir=self.use_tmp_dir,
         )
 
     def delete_accumulators(self):

--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import struct
 import tempfile
+from typing import Dict, Optional, Union
 
 from sisyphus import *
 
@@ -360,15 +361,15 @@ class LinearAlignmentJob(MergeMixturesJob):
 class EstimateMixturesJob(MergeMixturesJob):
     def __init__(
         self,
-        crp,
-        old_mixtures,
-        feature_flow,
-        alignment,
-        split_first=True,
-        keep_accumulators=False,
-        extra_merge_args=None,
-        extra_config=None,
-        extra_post_config=None,
+        crp: rasr.CommonRasrParameters,
+        old_mixtures: tk.Path,
+        feature_flow: Union[str, tk.Path, rasr.FlagDependentFlowAttribute],
+        alignment: Union[str, tk.Path, rasr.FlagDependentFlowAttribute],
+        split_first: bool = True,
+        keep_accumulators: bool = False,
+        extra_merge_args: Optional[Dict] = None,
+        extra_config: Optional[rasr.RasrConfig] = None,
+        extra_post_config: Optional[rasr.RasrConfig] = None,
     ):
         self.set_vis_name("Split Mixtures" if split_first else "Accumulate Mixtures")
 
@@ -423,7 +424,9 @@ class EstimateMixturesJob(MergeMixturesJob):
         self.write_run_script(self.exe, "accumulate-mixtures.config", "accumulate.sh")
 
     def accumulate(self, task_id):
-        self.run_script(task_id, self.out_log_file[task_id], "./accumulate.sh")
+        self.run_script(
+            task_id, self.out_log_file[task_id], "./accumulate.sh", use_tmp_dir=True
+        )
 
     def delete_accumulators(self):
         for i in range(1, self.concurrent + 1):

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -137,9 +137,7 @@ fi
             os.path.basename(tk.uncached_path(log_file)), ".gz"
         )
 
-        if use_tmp_dir or (
-            hasattr(gs, "JOB_RUN_RASR_TMP_DIR") and gs.JOB_RUN_RASR_TMP_DIR
-        ):
+        if use_tmp_dir:
             with tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX) as tmp_dir:
                 print("using temp-dir: %s" % tmp_dir)
                 try:

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -1,7 +1,11 @@
 __all__ = ["RasrCommand"]
 
 import logging
+import shutil
+import tempfile
 import time
+
+from typing import List, Optional, Union
 
 from sisyphus import *
 
@@ -52,6 +56,7 @@ class RasrCommand:
         :param str config:
         :param str filename:
         :param str extra_code:
+        :param str extra_args:
         """
         with open(filename, "wt") as f:
             f.write(
@@ -118,19 +123,53 @@ fi
             return cls.default_exe(default_exe_name)
         return specific_exe
 
-    def run_script(self, task_id, log_file, cmd="./run.sh", args=None, retries=2):
+    def run_script(
+        self,
+        task_id: int,
+        log_file: Union[str, Path],
+        cmd: str = "./run.sh",
+        args: List = None,
+        retries: int = 2,
+        use_tmp_dir: bool = False,
+    ):
         args = [] if args is None else args
         tmp_log_file = remove_suffix(
             os.path.basename(tk.uncached_path(log_file)), ".gz"
         )
-        self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries)
+
+        if use_tmp_dir or (
+            hasattr(gs, "JOB_RUN_RASR_TMP_DIR") and gs.JOB_RUN_RASR_TMP_DIR
+        ):
+            with tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX) as tmp_dir:
+                print("using temp-dir: %s" % tmp_dir)
+                try:
+                    self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries, tmp_dir)
+                    file_names = os.listdir(tmp_dir)
+                    for fn in file_names:
+                        shutil.move("%s/%s" % (tmp_dir, fn), fn)
+                except Exception as e:
+                    print(
+                        "'%s' crashed - copy temporary work folder as 'crash_dir'" % cmd
+                    )
+                    shutil.copytree(tmp_dir, "crash_dir")
+                    raise e
+        else:
+            self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries)
+
         zmove(tmp_log_file, tk.uncached_path(log_file))
 
-    def run_cmd(self, cmd, args=None, retries=2):
+    def run_cmd(
+        self,
+        cmd: str,
+        args: Optional[List[str]] = None,
+        retries: int = 2,
+        cwd: Optional[str] = None,
+    ):
         """
-        :param str cmd:
-        :param list[str]|None args:
-        :param int retries:
+        :param cmd:
+        :param args:
+        :param retries:
+        :param cwd: execute cmd in this dir
         """
         args = [] if args is None else args
         retries = max(0, retries)
@@ -140,7 +179,7 @@ fi
         for t in range(retries + 1):
             try:
                 self.cleanup_before_run(cmd, t, *args)
-                sp.check_call([cmd] + [str(arg) for arg in args])
+                sp.check_call([cmd] + [str(arg) for arg in args], cwd=cwd)
                 break
             except sp.CalledProcessError as e:
                 logging.warning(

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -2,6 +2,7 @@ __all__ = ["RasrCommand"]
 
 import logging
 import shutil
+import subprocess as sp
 import tempfile
 import time
 

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -139,6 +139,7 @@ fi
         )
 
         if use_tmp_dir:
+            date_time_cur = time.strftime("%y%m%d-%H%M%S", time.localtime())
             with tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX) as tmp_dir:
                 print("using temp-dir: %s" % tmp_dir)
                 try:
@@ -150,7 +151,7 @@ fi
                     print(
                         "'%s' crashed - copy temporary work folder as 'crash_dir'" % cmd
                     )
-                    shutil.copytree(tmp_dir, "crash_dir")
+                    shutil.copytree(tmp_dir, "crash_dir_" + date_time_cur)
                     raise e
         else:
             self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries)


### PR DESCRIPTION
The idea is to allow the user to specify a temporary dir in which the rasr job will be executed. This allows the job to be executed locally and not directly on a network file system.
This can be set job specific or globally via `settings.py`. At the moment this is hardcoded for EstimateMixturesJob.

- Do you think this is the correct place to add this?
- Should this be globally set? Hard-coded?

Would like to get feedback on this.