### PR TITLE
Rework of BPE jobs for LM pipeline

### DIFF
--- a/text/label/subword_nmt/apply.py
+++ b/text/label/subword_nmt/apply.py
@@ -123,7 +123,7 @@ class ApplyBPEToTextJob(Job):
         :param text_file: words text file to convert to bpe
         :param bpe_codes: bpe codes file, e.g. ReturnnTrainBpeJob.out_bpe_codes
         :param bpe_vocab: if provided, then merge operations that produce OOV are reverted,
-            use e.g. ReturnnTrainBpeJob.out_bpe_apply_vocab
+            use e.g. ReturnnTrainBpeJob.out_bpe_dummy_count_vocab
         :param subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
         :param gzip_output: use gzip on the output text
         """

--- a/text/label/subword_nmt/apply.py
+++ b/text/label/subword_nmt/apply.py
@@ -2,7 +2,9 @@ __all__ = ["ApplyBPEModelToLexiconJob", "ApplyBPEToTextJob"]
 
 import subprocess as sp
 import os
+import shutil
 import sys
+import tempfile
 import xml.etree.ElementTree as ET
 
 from sisyphus import *
@@ -106,39 +108,68 @@ class ApplyBPEToTextJob(Job):
     Apply BPE codes on a text file
     """
 
-    def __init__(self, text_file, bpe_codes, bpe_vocab=None, subword_nmt_repo=None):
+    __sis_hash_exclude__ = {"gzip_output": False}
+
+    def __init__(
+        self,
+        text_file: tk.Path,
+        bpe_codes: tk.Path,
+        bpe_vocab=None,
+        subword_nmt_repo=None,
+        gzip_output=False,
+    ):
         """
         :param Path text_file: words text file to convert to bpe
-        :param Path bpe_codes: bpe codes file
-        :param Path|None bpe_vocab: if provided, then merge operations that produce OOV are reverted
-        :param Path|str|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
+        :param Path bpe_codes: bpe codes file, e.g. ReturnnTrainBpeJob.out_bpe_codes
+        :param Path|None bpe_vocab: if provided, then merge operations that produce OOV are reverted,
+            use e.g. ReturnnTrainBpeJob.out_bpe_apply_vocab
+        :param Path|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
         """
         self.text_file = text_file
         self.bpe_codes = bpe_codes
         self.bpe_vocab = bpe_vocab
         self.subword_nmt_repo = (
-            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+            subword_nmt_repo
+            if subword_nmt_repo is not None
+            else tk.Path(gs.SUBWORD_NMT_PATH)
         )
+        self.gzip_output = gzip_output
 
-        self.out_bpe_text = self.output_path("words_to_bpe.txt")
+        self.out_bpe_text = self.output_path(
+            "words_to_bpe.txt.gz" if gzip_output else "words_to_bpe.txt"
+        )
 
     def tasks(self):
         yield Task("run", mini_task=True)
 
     def run(self):
-        cmd = [
-            sys.executable,
-            os.path.join(tk.uncached_path(self.subword_nmt_repo), "apply_bpe.py"),
-            "--input",
-            self.text_file.get_path(),
-            "--codes",
-            self.bpe_codes.get_path(),
-            "--output",
-            self.out_bpe_text.get_path(),
-        ]
+        with tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX) as tmp:
+            input_file = self.text_file.get_path()
+            tmp_infile = os.path.join(tmp, "in_text.txt")
+            tmp_outfile = os.path.join(tmp, "out_text.txt")
+            with util.uopen(tmp_infile, "wt") as out:
+                sp.call(["zcat", "-f", input_file], stdout=out)
+            cmd = [
+                sys.executable,
+                os.path.join(self.subword_nmt_repo.get_path(), "apply_bpe.py"),
+                "--input",
+                tmp_infile,
+                "--codes",
+                self.bpe_codes.get_path(),
+                "--output",
+                tmp_outfile,
+            ]
 
-        if self.bpe_vocab:
-            cmd += ["--vocabulary", self.bpe_vocab.get_path()]
+            if self.bpe_vocab:
+                cmd += ["--vocabulary", self.bpe_vocab.get_path()]
 
-        util.create_executable("apply_bpe.sh", cmd)
-        sp.run(cmd, check=True)
+            util.create_executable("apply_bpe.sh", cmd)
+            sp.run(cmd, check=True)
+
+            if self.gzip_output:
+                with util.uopen(tmp_outfile, "rt") as fin, util.uopen(
+                    self.out_bpe_text, "wb"
+                ) as fout:
+                    sp.call(["gzip"], stdin=fin, stdout=fout)
+            else:
+                shutil.copy(tmp_outfile, self.out_bpe_text.get_path())

--- a/text/label/subword_nmt/apply.py
+++ b/text/label/subword_nmt/apply.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import tempfile
+from typing import Optional
 import xml.etree.ElementTree as ET
 
 from sisyphus import *
@@ -114,16 +115,17 @@ class ApplyBPEToTextJob(Job):
         self,
         text_file: tk.Path,
         bpe_codes: tk.Path,
-        bpe_vocab=None,
-        subword_nmt_repo=None,
-        gzip_output=False,
+        bpe_vocab: Optional[tk.Path] = None,
+        subword_nmt_repo: Optional[tk.Path] = None,
+        gzip_output: bool = False,
     ):
         """
-        :param Path text_file: words text file to convert to bpe
-        :param Path bpe_codes: bpe codes file, e.g. ReturnnTrainBpeJob.out_bpe_codes
-        :param Path|None bpe_vocab: if provided, then merge operations that produce OOV are reverted,
+        :param text_file: words text file to convert to bpe
+        :param bpe_codes: bpe codes file, e.g. ReturnnTrainBpeJob.out_bpe_codes
+        :param bpe_vocab: if provided, then merge operations that produce OOV are reverted,
             use e.g. ReturnnTrainBpeJob.out_bpe_apply_vocab
-        :param Path|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
+        :param subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
+        :param gzip_output: use gzip on the output text
         """
         self.text_file = text_file
         self.bpe_codes = bpe_codes

--- a/text/label/subword_nmt/train.py
+++ b/text/label/subword_nmt/train.py
@@ -103,7 +103,7 @@ class ReturnnTrainBpeJob(Job):
         - bpe_codes: the codes file to apply BPE to any text
         - bpe_vocab: the index vocab in the form of {"<token>": <index>, ...} that can be used e.g. for RETURNN
             Will contain <s> and </s> pointing to index 0 and the unk_label pointing to index 1
-        - bpe_apply_vocab: a text file containing all words, to be used with the `ApplyBPEToTextJob`
+        - bpe_dummy_count_vocab: a text file containing all words, to be used with the `ApplyBPEToTextJob`
             DOES NOT INCLUDE COUNTS, but just set each count to -1. Is used to not cause invalid merges
             when converting text to the BPE form.
         - vocab_size: variable containing the number of indices

--- a/text/label/subword_nmt/train.py
+++ b/text/label/subword_nmt/train.py
@@ -133,7 +133,7 @@ class ReturnnTrainBpeJob(Job):
 
         self.out_bpe_codes = self.output_path("bpe.codes")
         self.out_bpe_vocab = self.output_path("bpe.vocab")
-        self.out_bpe_apply_vocab = self.output_path("bpe.vocab.txt")
+        self.out_bpe_dummy_count_vocab = self.output_path("bpe.dummy_count.vocab")
         self.out_vocab_size = self.output_var("vocab_size")
 
     def run(self):
@@ -178,7 +178,7 @@ class ReturnnTrainBpeJob(Job):
         sp.run(bpe_vocab_cmd, check=True)
 
         with util.uopen(self.out_bpe_vocab) as f, util.uopen(
-            self.out_bpe_apply_vocab, "wt"
+            self.out_bpe_dummy_count_vocab, "wt"
         ) as txt_vocab:
             vocab = eval(f.read())
             num_labels = max(list(vocab.values())) + 1  # 0-based index

--- a/text/label/subword_nmt/train.py
+++ b/text/label/subword_nmt/train.py
@@ -117,7 +117,7 @@ class ReturnnTrainBpeJob(Job):
         subword_nmt_repo: Optional[tk.Path] = None,
     ):
         """
-        :param text_file: corpus text file, only accepts uncompressed text
+        :param text_file: corpus text file, .gz compressed or uncompressed
         :param int bpe_size: number of BPE merge operations
         :param str unk_label: unknown label
         :param Path|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`

--- a/text/label/subword_nmt/train.py
+++ b/text/label/subword_nmt/train.py
@@ -104,7 +104,7 @@ class ReturnnTrainBpeJob(Job):
         - bpe_vocab: the index vocab in the form of {"<token>": <index>, ...} that can be used e.g. for RETURNN
             Will contain <s> and </s> pointing to index 0 and the unk_label pointing to index 1
         - bpe_apply_vocab: a text file containing all words, to be used with the `ApplyBPEToTextJob`
-            DOES NOT INCLUDE COUNTS, but just set each count to 100. Is used to not cause invalid merges
+            DOES NOT INCLUDE COUNTS, but just set each count to -1. Is used to not cause invalid merges
             when converting text to the BPE form.
         - vocab_size: variable containing the number of indices
     """
@@ -184,7 +184,7 @@ class ReturnnTrainBpeJob(Job):
             num_labels = max(list(vocab.values())) + 1  # 0-based index
             self.out_vocab_size.set(num_labels)
             for l in vocab.keys():
-                txt_vocab.write(f"{l} 100\n")
+                txt_vocab.write(f"{l} -1\n")
 
     def tasks(self):
         yield Task("run", rqmt={"cpu": 1, "mem": 2, "time": 4})

--- a/text/label/subword_nmt/train.py
+++ b/text/label/subword_nmt/train.py
@@ -1,9 +1,9 @@
 __all__ = ["TrainBPEModelJob", "ReturnnTrainBpeJob"]
 
-import gzip
 import subprocess as sp
 import os
 import sys
+from typing import Optional
 
 from sisyphus import *
 
@@ -95,33 +95,51 @@ class ReturnnTrainBpeJob(Job):
     """
     Create Bpe codes and vocab files compatible with RETURNN BytePairEncoding
     Repository:
-        https://github.com/albertz/subword-nmt
+        https://github.com/rwth-i6/subword-nmt
 
     This job can be used to produce BPE codes compatible to legacy (non-sisyphus) RETURNN setups.
+
+    Outputs:
+        - bpe_codes: the codes file to apply BPE to any text
+        - bpe_vocab: the index vocab in the form of {"<token>": <index>, ...} that can be used e.g. for RETURNN
+            Will contain <s> and </s> pointing to index 0 and the unk_label pointing to index 1
+        - bpe_apply_vocab: a text file containing all words, to be used with the `ApplyBPEToTextJob`
+            DOES NOT INCLUDE COUNTS, but just set each count to 100. Is used to not cause invalid merges
+            when converting text to the BPE form.
+        - vocab_size: variable containing the number of indices
     """
 
-    def __init__(self, text_file, bpe_size, unk_label="UNK", subword_nmt_repo=None):
+    def __init__(
+        self,
+        text_file: tk.Path,
+        bpe_size: int,
+        unk_label: str = "UNK",
+        subword_nmt_repo: Optional[tk.Path] = None,
+    ):
         """
-        :param Path text_file: corpus text file
+        :param text_file: corpus text file, only accepts uncompressed text
         :param int bpe_size: number of BPE merge operations
         :param str unk_label: unknown label
-        :param Path|str|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
+        :param Path|None subword_nmt_repo: subword nmt repository path. see also `CloneGitRepositoryJob`
         """
         self.text_file = text_file
         self.bpe_size = bpe_size
         self.subword_nmt_repo = (
-            subword_nmt_repo if subword_nmt_repo is not None else gs.SUBWORD_NMT_PATH
+            subword_nmt_repo
+            if subword_nmt_repo is not None
+            else tk.Path(gs.SUBWORD_NMT_PATH)
         )
         self.unk_label = unk_label
 
         self.out_bpe_codes = self.output_path("bpe.codes")
         self.out_bpe_vocab = self.output_path("bpe.vocab")
+        self.out_bpe_apply_vocab = self.output_path("bpe.vocab.txt")
         self.out_vocab_size = self.output_var("vocab_size")
 
     def run(self):
         bpe_codes_cmd = [
             sys.executable,
-            os.path.join(tk.uncached_path(self.subword_nmt_repo), "learn_bpe.py"),
+            os.path.join(self.subword_nmt_repo.get_path(), "learn_bpe.py"),
             "--output",
             self.out_bpe_codes.get_path(),
             "--symbols",
@@ -145,7 +163,7 @@ class ReturnnTrainBpeJob(Job):
 
         bpe_vocab_cmd = [
             sys.executable,
-            os.path.join(tk.uncached_path(self.subword_nmt_repo), "create-py-vocab.py"),
+            os.path.join(self.subword_nmt_repo.get_path(), "create-py-vocab.py"),
             "--txt",
             self.text_file.get_path(),
             "--bpe",
@@ -159,9 +177,14 @@ class ReturnnTrainBpeJob(Job):
         util.create_executable("create_bpe_vocab.sh", bpe_vocab_cmd)
         sp.run(bpe_vocab_cmd, check=True)
 
-        with util.uopen(self.out_bpe_vocab) as f:
-            num_labels = max(list(eval(f.read()).values())) + 1  # 0-based index
+        with util.uopen(self.out_bpe_vocab) as f, util.uopen(
+            self.out_bpe_apply_vocab, "wt"
+        ) as txt_vocab:
+            vocab = eval(f.read())
+            num_labels = max(list(vocab.values())) + 1  # 0-based index
             self.out_vocab_size.set(num_labels)
+            for l in vocab.keys():
+                txt_vocab.write(f"{l} 100\n")
 
     def tasks(self):
         yield Task("run", rqmt={"cpu": 1, "mem": 2, "time": 4})


### PR DESCRIPTION
This one was a little bit tricky, so here the summary:

 - There are different kinds of "vocabulary" files that have different content or structure. A vocabulary in the sense of RETURNN is a `bpe_token -> index` mapping, while for the subword-nmt software this is a `bpe_token -> count` file. Within the bpe training I am now creating an artificial `bpe_token -> count` file (counts are all 100), so that the vocabulary parameter can be set to not cause invalid merges when applying bpe on unseen data via the apply job. 
 
If we want true counts in the future we can have an extra job for that, where we also supply a corpus to get the counts on.

The second change is that the apply job operates in a temp-dir and also allows for gzipped output (for LM stuff the data sizes can be quite large).

I hope I added sufficient documentation to not cause confusion.

