### PR TITLE
Tmp Dir: Introduce Copy List

### DIFF
--- a/mm/mixtures.py
+++ b/mm/mixtures.py
@@ -387,7 +387,8 @@ class EstimateMixturesJob(MergeMixturesJob):
         self.concurrent = crp.concurrent
 
         self._old_mixtures = old_mixtures
-        self.use_tmp_dir = False
+        self.use_tmp_dir = True
+        self.copy_list = ["accumulate-mixtures.config", "accumulate.sh", "alignment.flow"]
 
         self.out_log_file = self.log_file_output_path("accumulate", crp, True)
 
@@ -430,6 +431,7 @@ class EstimateMixturesJob(MergeMixturesJob):
             self.out_log_file[task_id],
             "./accumulate.sh",
             use_tmp_dir=self.use_tmp_dir,
+            copy_tmp_ls=self.copy_list if self.use_tmp_dir else None
         )
 
     def delete_accumulators(self):

--- a/rasr/command.py
+++ b/rasr/command.py
@@ -2,7 +2,6 @@ __all__ = ["RasrCommand"]
 
 import logging
 import shutil
-import subprocess as sp
 import tempfile
 import time
 
@@ -132,17 +131,28 @@ fi
         args: List = None,
         retries: int = 2,
         use_tmp_dir: bool = False,
+        copy_tmp_ls: Optional[List] = None,
     ):
         args = [] if args is None else args
         tmp_log_file = remove_suffix(
             os.path.basename(tk.uncached_path(log_file)), ".gz"
         )
 
-        if use_tmp_dir:
-            date_time_cur = time.strftime("%y%m%d-%H%M%S", time.localtime())
+        work_dir = os.path.abspath(os.curdir)
+        if use_tmp_dir or (
+            hasattr(gs, "JOB_RUN_RASR_TMP_DIR") and gs.JOB_RUN_RASR_TMP_DIR
+        ):
             with tempfile.TemporaryDirectory(prefix=gs.TMP_PREFIX) as tmp_dir:
                 print("using temp-dir: %s" % tmp_dir)
                 try:
+                    if copy_tmp_ls is None:
+                        assert task_id == 1, "Concurrent Jobs need a list of files to copy due to race conditions"
+                        file_names = os.listdir(work_dir)
+                    else:
+                        file_names = copy_tmp_ls
+                    for fn in file_names:
+                        print(fn)
+                        shutil.copy(os.path.join(work_dir, fn), "%s/%s" % (tmp_dir, fn))
                     self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries, tmp_dir)
                     file_names = os.listdir(tmp_dir)
                     for fn in file_names:
@@ -151,7 +161,8 @@ fi
                     print(
                         "'%s' crashed - copy temporary work folder as 'crash_dir'" % cmd
                     )
-                    shutil.copytree(tmp_dir, "crash_dir_" + date_time_cur)
+                    if "crash_dir_%d" % task_id not in os.listdir(work_dir):
+                        shutil.copytree(tmp_dir, "crash_dir_%d" % task_id)
                     raise e
         else:
             self.run_cmd(cmd, [task_id, tmp_log_file] + args, retries)


### PR DESCRIPTION
Handles #346 
This PR introduces a copy list for using a tmp dir with `run_script`. The reason for that is that this was the only way we could find to handle concurrent jobs which write files into the work folder without causing race conditions through this writing.
Since we manually need to enable using tmp dir usage, adding a copy list to those jobs which run with more than one concurrent job in the array should not be a problem.
Currently testing if works and approved can merge later.