### PR TITLE
Switchboard LDC Speakers, Fisher Transcriptions and corpus corrections

### DIFF
--- a/datasets/switchboard.py
+++ b/datasets/switchboard.py
@@ -170,6 +170,10 @@ class CreateLDCSwitchboardSpeakerListJob(Job):
     """
 
     def __init__(self, caller_tab_file, conv_tab_file):
+        """
+        :param caller_tab_file: caller_tab.csv from the Switchboard LDC documentation
+        :param conv_tab_file: conv_tab.csv from the Switchboard LDC documentation
+        """
         # locally create the download jobs
         self.caller_tab_file = caller_tab_file
         self.conv_tab_file = conv_tab_file

--- a/datasets/switchboard.py
+++ b/datasets/switchboard.py
@@ -281,11 +281,12 @@ class CreateSwitchboardBlissCorpusJob(Job):
                 rec_to_speaker[rec] = {"speaker_id": "speaker#" + str(unk_spk_id)}
                 unk_spk_id += 1
 
+        if self.skip_empty_ldc_file:
+            rec_to_segs.pop("sw02167B")
+
         for rec_name, segs in sorted(rec_to_segs.items()):
             recording = corpus.Recording()
             recording.name = rec_name
-            if self.skip_empty_ldc_file and rec_name == "sw02167B":
-                continue
             recording.audio = os.path.join(self.audio_dir.get_path(), rec_name + ".wav")
 
             assert os.path.exists(


### PR DESCRIPTION
This is the third and hopefully final PR for the switchboard corpus. (at least for i6_core, all the pipeline stuff will come later in experiments/common)

It adds:
 - LDC Speaker job to get the correct 520 speakers as intended by the switchboard corpus design
 - Fisher transcription job to create the training data for LMs (count or neural)
 -  Lowercase option and an "empty recording" ignore option for the broken recording in the original LDC data. I also made both the default now because this his how we should consistently work with it.