### PR TITLE
Add LmIndexVocabularyFromLexiconJob

### DIFF
--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -91,14 +91,13 @@ class LmIndexVocabularyFromLexiconJob(Job):
         assert unknown is not None
 
         if self.count_ordering_text is not None:
-            word_set = set(wordlist)
             word_counts = {}
             for w in wordlist:
                 word_counts[w] = 0
             with uopen(self.count_ordering_text, "rt") as f:
                 for line in f.readlines():
                     for word in line.strip().split(" "):
-                        if word in word_set:
+                        if word in word_counts:
                             word_counts[word] += 1
             wordlist = [
                 w

--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -34,6 +34,10 @@ class LmIndexVocabularyFromLexiconJob(Job):
     def __init__(
         self, bliss_lexicon: tk.Path, count_ordering_text: Optional[tk.Path] = None
     ):
+        """
+        :param bliss_lexicon: us the lemmas from the lexicon to define the indices
+        :param count_ordering_text: optional text that can be used to define the index order based on the lemma count
+        """
         self.bliss_lexicon = bliss_lexicon
         self.count_ordering_text = count_ordering_text
 


### PR DESCRIPTION
This is a job which creates an index vocab file for LM training based on a given lexicon. This job was missing to run any kind of consistent word-based Neural-LM training with our pipelines.