### PR TITLE
feat: Show highest finished training epoch in sis overview

### DIFF
--- a/returnn/training.py
+++ b/returnn/training.py
@@ -239,21 +239,27 @@ class ReturnnTrainingJob(Job):
         return run_cmd
 
     def info(self):
-        def try_load_lr_log(file_path: str):
+        def try_load_lr_log(file_path: str) -> Optional[dict]:
             # Used in parsing the learning rates
             @dataclass
             class EpochData:
                 learningRate: float
                 error: Dict[str, float]
 
-            with open(file_path, "rt") as file:
-                return eval(file.read().strip())
+            try:
+                with open(file_path, "rt") as file:
+                    return eval(file.read().strip())
+            except FileNotFoundError:
+                return None
 
         lr_file = os.path.join(
             self._sis_path(gs.JOB_WORK_DIR),
             self.returnn_config.get("learning_rate_file", "learning_rates"),
         )
         epochs = try_load_lr_log(lr_file)
+
+        if epochs is None:
+            return None
 
         if not isinstance(epochs, dict):
             raise TypeError(

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -237,6 +237,20 @@ class ReturnnTrainingJob(Job):
 
         return run_cmd
 
+    def info(self):
+        if self.out_checkpoints is None:
+            return None
+        # if self.keep_epochs is set, `self.out_checkpoints` will be incomplete, but
+        # using it is fast because `Path.available()` is cached.
+        available_checkpoints = [
+            k for k, ckpt in self.out_checkpoints.items() if ckpt.index_path.available()
+        ]
+        if len(available_checkpoints) == 0:
+            return None
+        max_ep = max(self.out_checkpoints)
+        max_available_ep = max(available_checkpoints)
+        return f"ep {max_available_ep}/{max_ep}"
+
     def path_available(self, path):
         # if job is finished the path is available
         res = super().path_available(path)

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -239,32 +239,21 @@ class ReturnnTrainingJob(Job):
         return run_cmd
 
     def info(self):
-        def try_load_lr_log(files: List[str]):
+        def try_load_lr_log(file_path: str):
             # Used in parsing the learning rates
             @dataclass
             class EpochData:
                 learningRate: float
                 error: Dict[str, float]
 
-            for file in files:
-                try:
-                    with open(file, "rt") as file:
-                        return eval(file.read().strip())
-                except FileNotFoundError:
-                    pass
+            with open(file_path, "rt") as file:
+                return eval(file.read().strip())
 
-            return None
-
-        lr_during_training = os.path.join(
+        lr_file = os.path.join(
             self._sis_path(gs.JOB_WORK_DIR),
             self.returnn_config.get("learning_rate_file", "learning_rates"),
         )
-        lr_after_training = self.out_learning_rates.get_path()
-
-        epochs = try_load_lr_log([lr_during_training, lr_after_training])
-
-        if epochs is None:
-            return None
+        epochs = try_load_lr_log(lr_file)
 
         if not isinstance(epochs, dict):
             raise TypeError(

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -259,7 +259,7 @@ class ReturnnTrainingJob(Job):
             self._sis_path(gs.JOB_WORK_DIR),
             self.returnn_config.get("learning_rate_file", "learning_rates"),
         )
-        lr_after_training = tk.uncached_path(self.out_learning_rates)
+        lr_after_training = self.out_learning_rates.get_path()
 
         epochs = try_load_lr_log([lr_during_training, lr_after_training])
 


### PR DESCRIPTION
This PR adds a small indicator showing RETURNN training progress. It shows the highest finished training epoch and the number of total epochs. I tried to keep it minimal.

Looks like this when run (here on a subclass):
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1683034/214350397-38304610-0c24-44d1-96a2-f6471c5ee2dc.png">

My understanding is that sisyphus regularly calls `Job.info()`, so the counter _should_ update itself. Please correct me if I'm wrong.

I'm open for suggestions for visual improvements. Looking forward to y'all's reviews!