### PR TITLE
Fix old setups that use DelayedFormat over join_right

### DIFF
--- a/util.py
+++ b/util.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 from typing import Optional
 
 from sisyphus import *
-from sisyphus.delayed_ops import DelayedBase
+from sisyphus.delayed_ops import DelayedBase, DelayedFormat
 
 Path = setup_path(__package__)
 Variable = tk.Variable
@@ -332,6 +332,14 @@ def get_executable_path(
                 f"use of str is deprecated, please provide a Path object for {path}"
             )
             return tk.Path(path)
+        elif isinstance(path, DelayedFormat):
+            logging.warning(
+                f"use of a DelayedFormat is deprecated, please use Path.join_right to provide a Path object for {path}"
+            )
+            if isinstance(path.args[0], tk.Path):
+                return path.args[0].join_right(path.args[1])
+            else:
+                return tk.Path(path.get())
         assert False, f"unsupported type of {type(path)} for input {path}"
     if getattr(gs, gs_member_name, None) is not None:
         if gs_member_name not in already_printed_gs_warnings:

--- a/util.py
+++ b/util.py
@@ -336,7 +336,12 @@ def get_executable_path(
             logging.warning(
                 f"use of a DelayedFormat is deprecated, please use Path.join_right to provide a Path object for {path}"
             )
-            if isinstance(path.args[0], tk.Path):
+            if (
+                len(path.args) == 2 
+                and isinstance(path.args[0], tk.Path) 
+                and isinstance(path.args[1], str)
+                and path.string == "{}/{}"
+            ):
                 return path.args[0].join_right(path.args[1])
             else:
                 return tk.Path(path.get())

--- a/util.py
+++ b/util.py
@@ -337,8 +337,8 @@ def get_executable_path(
                 f"use of a DelayedFormat is deprecated, please use Path.join_right to provide a Path object for {path}"
             )
             if (
-                len(path.args) == 2 
-                and isinstance(path.args[0], tk.Path) 
+                len(path.args) == 2
+                and isinstance(path.args[0], tk.Path)
                 and isinstance(path.args[1], str)
                 and path.string == "{}/{}"
             ):


### PR DESCRIPTION
In #261 we broke some old setups that used DelayedFormat to append a custom location to an existing tk.Path object. This adds support  and a warning for these old setups.