### PR TITLE
add workflow to trigger bitbucket pipeline

### DIFF
--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -4,7 +4,7 @@ env:
   auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
-  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'
+  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes+tests"}}, "variables": [{"key": "i6_core_branch", "value": "'
 on:
   push:
     branches:

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -1,4 +1,12 @@
 name: AppTek hashes
+env:
+  api_url: "https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/"
+  auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
+  get_header: "-X GET -s -H 'Accept: application/json'"
+  post_header: "-X POST -s -H 'Content-Type: application/json'"
+  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'${GITHUB_HEAD_REF}'"}]}'
+
+
 on:
   push:
     branches:
@@ -15,35 +23,24 @@ jobs:
         python-version: 3.8
     - name: Start Bitbucket Pipeline
       run: |
-        curl -X POST -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
-            -H 'Content-Type: application/json' \
-            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/ \
-            -d '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration",
-                 "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}},
-                 "variables": [{"key": "i6_core_branch", "value": "'${GITHUB_HEAD_REF}'"}]}' |\
-        python -c "import sys,json; print(json.load(sys.stdin)['uuid'])" |\
-        sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
+        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d ${{ env.post_content }} |\
+        python -c "import sys,json; print(json.load(sys.stdin)['uuid'].replace('{','%7B').replace('}','%7D'))" > pipeline_uuid.txt
     - name: Wait for Results
       run: |
+        sleep 300
         while [ COMPLETED != $(\
-            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
-            -H 'Accept: application/json' \
-            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])") \
-            ]; do sleep 10 ; done
+            ]; do sleep 30 ; done
         [ SUCCESSFUL == $(\
-            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
-            -H 'Accept: application/json' \
-            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])") \
         ] 
     - name: Report Error
       if: failure()
       run: |
         echo "::error ::The AppTek hashtest pipeline #"$(\
-            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
-            -H 'Accept: application/json' \
-            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['build_number'])") \
             " failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -13,11 +13,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - name: Print Branch Name for later
-      run: |
-        echo GITHUB_REF is ${GITHUB_REF}
-        echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
-        echo GITHUB_REF_NAME is ${GITHUB_REF_NAME}
     - name: Start Bitbucket Pipeline
       run: |
         curl -X POST -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -4,7 +4,7 @@ env:
   auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
-  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes+tests"}}, "variables": [{"key": "i6_core_branch", "value": "'
+  post_content: '{"target": {"ref_type": "branch", "ref_name": "main", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes+tests"}}, "variables": [{"key": "i6_core_branch", "value": "'
 on:
   push:
     branches:

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -31,7 +31,7 @@ jobs:
             -H 'Accept: application/json' \
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])" `\
-            ]; do sleep(10); done
+            ]; do sleep 10 ; done
         [ SUCCESSFUL == `\
             curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
             -H 'Accept: application/json' \

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -23,7 +23,9 @@ jobs:
         curl -X POST -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
             -H 'Content-Type: application/json' \
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/ \
-            -d '{"target": {"ref_type": "branch", "ref_name": "main","type": "pipeline_ref_target"}}' |\
+            -d '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration",
+                 "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}},
+                 "variables": [{"key": "i6_core_branch", "value": "'${GITHUB_HEAD_REF}'"}]}' |\
         python -c "import sys,json; print(json.load(sys.stdin)['uuid'])" |\
         sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -1,0 +1,42 @@
+name: hashes
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test-hashes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+        cache: "pip"
+    - name: Print Branch Name for later
+      run: |
+        echo ${GITHUB_REF##*/}
+    - name: Start Bitbucket Pipeline
+      run: |
+        curl -X POST -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
+            -H 'Content-Type: application/json' \
+            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/ \
+            -d '{"target": {"ref_type": "branch", "ref_name": "main","type": "pipeline_ref_target"}}' |\
+        python -c "import sys,json; print(json.load(sys.stdin)['uuid'])" |\
+        sed '/{/%7B/' | sed '/}/%7D/' > pipeline_uuid.txt
+    - name: Wait for Results
+      run: |
+        while [ IN_PROGRESS == `\
+            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
+            -H 'Accept: application/json' \
+            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])" `\
+            ]; do sleep(10); done
+        [ SUCCESSFUL == `\
+            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
+            -H 'Accept: application/json' \
+            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])" `\
+        ]
+

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -4,7 +4,7 @@ env:
   auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
-  post_content: '\'{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "\''
+  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'
 on:
   push:
     branches:
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.8
     - name: Start Bitbucket Pipeline
       run: |
-        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d ${{ env.post_content }}${GITHUB_HEAD_REF}'"}]}' |\
+        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d '${{ env.post_content }}'${GITHUB_HEAD_REF}'"}]}' |\
         python -c "import sys,json; print(json.load(sys.stdin)['uuid'].replace('{','%7B').replace('}','%7D'))" > pipeline_uuid.txt
     - name: Wait for Results
       run: |

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -40,6 +40,6 @@ jobs:
         echo "::error ::The AppTek hashtest pipeline #"$(\
             curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
             jq -r '.build_number') \
-            " failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
+            "failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
         exit 1
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -41,4 +41,5 @@ jobs:
             curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['build_number'])") \
             " failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
+        exit 1
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -23,7 +23,7 @@ jobs:
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/ \
             -d '{"target": {"ref_type": "branch", "ref_name": "main","type": "pipeline_ref_target"}}' |\
         python -c "import sys,json; print(json.load(sys.stdin)['uuid'])" |\
-        sed '/{/%7B/' | sed '/}/%7D/' > pipeline_uuid.txt
+        sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results
       run: |
         while [ IN_PROGRESS == `\

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -15,7 +15,9 @@ jobs:
         python-version: 3.8
     - name: Print Branch Name for later
       run: |
-        echo ${GITHUB_REF##*/}
+        echo GITHUB_REF is ${GITHUB_REF}
+        echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
+        echo GITHUB_REF_NAME is ${GITHUB_REF_NAME}
     - name: Start Bitbucket Pipeline
       run: |
         curl -X POST -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -4,7 +4,7 @@ env:
   auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
-  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'
+  post_content: '\'{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "\''
 on:
   push:
     branches:

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -37,4 +37,13 @@ jobs:
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
             python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])") \
         ] 
+    - name: Report Error
+      if: failure()
+      run: |
+        echo "::error ::The AppTek hashtest pipeline #"$(\
+            curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
+            -H 'Accept: application/json' \
+            https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
+            python3 -c "import sys,json; print(json.load(sys.stdin)['build_number'])") \
+            " failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -4,7 +4,7 @@ env:
   auth_token: "-H 'Authorization: Bearer ${{ secrets.APPTEK_BITBUCKET_AUTHENTICATION }}'"
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
-  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'${GITHUB_HEAD_REF}'"}]}'
+  post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'
 on:
   push:
     branches:
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.8
     - name: Start Bitbucket Pipeline
       run: |
-        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d ${{ env.post_content }} |\
+        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d ${{ env.post_content }}${GITHUB_HEAD_REF}'"}]}' |\
         python -c "import sys,json; print(json.load(sys.stdin)['uuid'].replace('{','%7B').replace('}','%7D'))" > pipeline_uuid.txt
     - name: Wait for Results
       run: |

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -28,7 +28,7 @@ jobs:
         sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results
       run: |
-        while [ IN_PROGRESS == $(\
+        while [ COMPLETED != $(\
             curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
             -H 'Accept: application/json' \
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -22,24 +22,24 @@ jobs:
     - name: Start Bitbucket Pipeline
       run: |
         curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d '${{ env.post_content }}'${GITHUB_HEAD_REF}'"}]}' |\
-        python -c "import sys,json; print(json.load(sys.stdin)['uuid'].replace('{','%7B').replace('}','%7D'))" > pipeline_uuid.txt
+        jq -r '.uuid' | sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results
       run: |
         sleep 300
         while [ COMPLETED != $(\
             curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
-            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])") \
+            jq -r '.state.name') \
             ]; do sleep 30 ; done
         [ SUCCESSFUL == $(\
             curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
-            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])") \
+            jq -r '.state.result.name') \
         ] 
     - name: Report Error
       if: failure()
       run: |
         echo "::error ::The AppTek hashtest pipeline #"$(\
             curl ${{ env.get_header }} ${{ env.auth_token}} ${{ env.api_url }}$(cat pipeline_uuid.txt) |\
-            python3 -c "import sys,json; print(json.load(sys.stdin)['build_number'])") \
+            jq -r '.build_number') \
             " failed. Please contact {wmichel,ebeck}@apptek.com to find out why."
         exit 1
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -28,16 +28,16 @@ jobs:
         sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results
       run: |
-        while [ IN_PROGRESS == `\
+        while [ IN_PROGRESS == $(\
             curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
             -H 'Accept: application/json' \
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
-            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])" `\
+            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['name'])") \
             ]; do sleep 10 ; done
-        [ SUCCESSFUL == `\
+        [ SUCCESSFUL == $(\
             curl -X GET -s -u ${{ secrets.MICHEL_BITBUCKET_AUTHENTICATION }} \
             -H 'Accept: application/json' \
             https://api.bitbucket.org/2.0/repositories/omnifluent/apptek_asr/pipelines/$(cat pipeline_uuid.txt) |\
-            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])" `\
-        ]
+            python3 -c "import sys,json; print(json.load(sys.stdin)['state']['result']['name'])") \
+        ] 
 

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -1,4 +1,4 @@
-name: hashes
+name: AppTek hashes
 on:
   push:
     branches:
@@ -13,7 +13,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8
-        cache: "pip"
     - name: Print Branch Name for later
       run: |
         echo ${GITHUB_REF##*/}

--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -5,8 +5,6 @@ env:
   get_header: "-X GET -s -H 'Accept: application/json'"
   post_header: "-X POST -s -H 'Content-Type: application/json'"
   post_content: '{"target": {"ref_type": "branch", "ref_name": "willi-i6_core-integration", "type": "pipeline_ref_target", "selector": {"type": "custom", "pattern": "hashes-only"}}, "variables": [{"key": "i6_core_branch", "value": "'${GITHUB_HEAD_REF}'"}]}'
-
-
 on:
   push:
     branches:

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -28,6 +28,7 @@ class ApplyG2PModelJob(Job):
         g2p_python=None,
         filter_empty_words=False,
         concurrent=1,
+        nonce="this value is not needed",
     ):
         """
         :param Path g2p_model:
@@ -47,6 +48,7 @@ class ApplyG2PModelJob(Job):
         self.word_list = word_list_file
         self.filter_empty_words = filter_empty_words
         self.concurrent = concurrent
+        self.nonce = nonce
 
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
         self.out_g2p_untranslated = self.output_path("g2p.untranslated")

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -28,6 +28,7 @@ class ApplyG2PModelJob(Job):
         g2p_python=None,
         filter_empty_words=False,
         concurrent=1,
+        nonce="this parameter is not needed",
     ):
         """
         :param Path g2p_model:
@@ -47,6 +48,7 @@ class ApplyG2PModelJob(Job):
         self.word_list = word_list_file
         self.filter_empty_words = filter_empty_words
         self.concurrent = concurrent
+        self.nonce = nonce
 
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
         self.out_g2p_untranslated = self.output_path("g2p.untranslated")

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -28,7 +28,6 @@ class ApplyG2PModelJob(Job):
         g2p_python=None,
         filter_empty_words=False,
         concurrent=1,
-        nonce="this parameter is not needed",
     ):
         """
         :param Path g2p_model:
@@ -48,7 +47,6 @@ class ApplyG2PModelJob(Job):
         self.word_list = word_list_file
         self.filter_empty_words = filter_empty_words
         self.concurrent = concurrent
-        self.nonce = nonce
 
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
         self.out_g2p_untranslated = self.output_path("g2p.untranslated")

--- a/g2p/apply.py
+++ b/g2p/apply.py
@@ -28,7 +28,6 @@ class ApplyG2PModelJob(Job):
         g2p_python=None,
         filter_empty_words=False,
         concurrent=1,
-        nonce="this value is not needed",
     ):
         """
         :param Path g2p_model:
@@ -48,7 +47,6 @@ class ApplyG2PModelJob(Job):
         self.word_list = word_list_file
         self.filter_empty_words = filter_empty_words
         self.concurrent = concurrent
-        self.nonce = nonce
 
         self.out_g2p_lexicon = self.output_path("g2p.lexicon")
         self.out_g2p_untranslated = self.output_path("g2p.untranslated")


### PR DESCRIPTION
The general plan is the following
* this workflow triggers a pipeline to be run on bitbucket 
* we pass the current branch name to bitbucket
* bitbucket clones the branch of the pr instead of main
* this workflow waits while bitbucket runs the pipeline
* this workflow returns result of pipeline

General TODOS
* all done

Security concerns:
* the authentication token is stored inside a github secret that only owners(?) od i6_core have read access to
* the contents of the secret are redacted from all logs
* users could create malicious pull requests changing the workflow of i6_core wich accesses the token but
a) the token only allows to start/stop/read existing pipelines
b) github does not automatically run workflows for first time contributors