### PR TITLE
add default branch for apptek workflow

### DIFF
--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.8
     - name: Start Bitbucket Pipeline
       run: |
-        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d '${{ env.post_content }}'${GITHUB_HEAD_REF}'"}]}' |\
+        curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d '${{ env.post_content }}'${GITHUB_HEAD_REF:-main}'"}]}' |\
         jq -r '.uuid' | sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
     - name: Wait for Results
       run: |


### PR DESCRIPTION
As the environment variable `${GITHUB_HEAD_REF}` is only set during a PR, therefore currently the workflow breaks after the merge on the main branch. As a quick fix, I add the branch name "main" as a fallback value.

This will break if we rename main or if somebody wants to run a manual test for a specific branch outside of a pull request.