### PR TITLE
SearchWordsToCTMJob, empty_seq_label option

### DIFF
--- a/returnn/search.py
+++ b/returnn/search.py
@@ -375,9 +375,6 @@ class SearchWordsToCTMJob(Job):
         :param Path recog_words_file: search output file from RETURNN
         :param Path bliss_corpus: bliss xml corpus
         :param bool filter_tags: if set to True, tags such as [noise] will be filtered out
-        :param empty_seq_label: if set, this label will be used for empty sequences,
-            otherwise empty sequences do not have any entries
-            (but an empty seq usually causes sclite to fail, so you probably always want to set this)
         """
         self.recog_words_file = recog_words_file
         self.bliss_corpus = bliss_corpus

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -370,9 +370,7 @@ class SearchWordsToCTMJob(Job):
     Convert RETURNN search output file into CTM format file (does not support n-best lists yet)
     """
 
-    __sis_hash_exclude__ = {"empty_seq_label": None}
-
-    def __init__(self, recog_words_file, bliss_corpus, filter_tags=True, *, empty_seq_label: Optional[str] = None):
+    def __init__(self, recog_words_file, bliss_corpus, filter_tags=True):
         """
         :param Path recog_words_file: search output file from RETURNN
         :param Path bliss_corpus: bliss xml corpus
@@ -384,7 +382,6 @@ class SearchWordsToCTMJob(Job):
         self.recog_words_file = recog_words_file
         self.bliss_corpus = bliss_corpus
         self.filter_tags = filter_tags
-        self.empty_seq_label = empty_seq_label
 
         self.out_ctm_file = self.output_path("search.ctm")
 
@@ -422,14 +419,14 @@ class SearchWordsToCTMJob(Job):
                         )
                     )
                     count += 1
-                if count == 0 and self.empty_seq_label:
+                if count == 0:
                     out.write(
                         "%s 1 %f %f %s 0.99\n"
                         % (
                             seg.recording.name,
                             seg_start,
                             avg_dur,
-                            self.empty_seq_label,
+                            "<empty-sequence>",
                         )
                     )
 

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -417,6 +417,12 @@ class SearchWordsToCTMJob(Job):
                     )
                     count += 1
                 if count == 0:
+                    # sclite cannot handle empty sequences, and would stop with an error like:
+                    #   hyp file '4515-11057-0054' and ref file '4515-11057-0053' not synchronized
+                    #   sclite: Alignment failed.  Exiting
+                    # So we make sure it is never empty.
+                    # For the WER, it should not matter, assuming the reference sequence is non-empty,
+                    # you will anyway get a WER of 100% for this sequence.
                     out.write(
                         "%s 1 %f %f %s 0.99\n"
                         % (

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -15,7 +15,7 @@ import logging
 import os
 import shutil
 import subprocess as sp
-from typing import Optional, Any, Union, Set, Dict
+from typing import Any, Union, Set, Dict
 
 from sisyphus import *
 


### PR DESCRIPTION
Fix #368.

Note that I'm unsure about a reasonable default. I think we have a conflict between:

- Keeping hash the same.
- Keeping behavior the same for a given hash.
- Reasonable default which probably would be used by everyone.

Note: I personally would just change and fix the behavior, maybe without even adding an option, as any such ctm files were anyway broken for sclite.