### PR TITLE
DumpHDFJob: write dump config into explicit file

### DIFF
--- a/.github/workflows/job_tests.yml
+++ b/.github/workflows/job_tests.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           repository: "rwth-i6/sisyphus"
           path: "sisyphus"
+      - uses: actions/checkout@v2
+        with:
+          repository: "rwth-i6/returnn"
+          path: "sisyphus"
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/job_tests.yml
+++ b/.github/workflows/job_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: "rwth-i6/returnn"
-          path: "sisyphus"
+          path: "returnn"
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -80,7 +80,10 @@ class ReturnnDumpHDFJob(Job):
         data = self.data
         if isinstance(data, dict):
             instanciate_delayed(data)
-            data = str(data)
+            with open("dataset.config", "wt") as dataset_file:
+                dataset_file.write("#!rnn.py\n")
+                dataset_file.write("train = %s\n" % str(data))
+            data = "dataset.config"
         elif isinstance(data, tk.Path):
             data = data.get_path()
 

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -181,7 +181,10 @@ class ReturnnRasrDumpHDFJob(ReturnnDumpHDFJob):
         self.alignment = alignment
         self.rasr_exe = rasr.RasrCommand.select_exe(crp.nn_trainer_exe, "nn-trainer")
         self.feature_flow = ReturnnRasrTrainingJob.create_flow(feature_flow, alignment)
-        (self.rasr_config, self.rasr_post_config,) = ReturnnRasrTrainingJob.create_config(
+        (
+            self.rasr_config,
+            self.rasr_post_config,
+        ) = ReturnnRasrTrainingJob.create_config(
             crp=crp,
             alignment=alignment,
             num_classes=num_classes,

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -74,18 +74,27 @@ class ReturnnDumpHDFJob(Job):
         self.out_hdf = self.output_path("data.hdf")
 
     def tasks(self):
+        if isinstance(self.data, (dict, str)):
+            yield Task("write_config", mini_task=True)
         yield Task("run", resume="run", rqmt=self.rqmt)
 
-    def run(self):
+    def write_config(self):
+        """
+        Optionally writes a config if self.data is either of type str or a dict, i.e.g not a tk.Path
+        """
         data = self.data
-        if isinstance(data, dict):
-            instanciate_delayed(data)
-            with open("dataset.config", "wt") as dataset_file:
-                dataset_file.write("#!rnn.py\n")
-                dataset_file.write("train = %s\n" % str(data))
-            data = "dataset.config"
-        elif isinstance(data, tk.Path):
-            data = data.get_path()
+        instanciate_delayed(data)
+        data = str(data)
+        with open("dataset.config", "wt") as dataset_file:
+            dataset_file.write("#!rnn.py\n")
+            dataset_file.write("train = %s\n" % str(data))
+        self.data = "dataset.config"
+
+    def run(self):
+        if isinstance(self.data, tk.Path):
+            data = self.data.get_path()
+        else:
+            data = self.data
 
         (fd, tmp_hdf_file) = tempfile.mkstemp(prefix=gs.TMP_PREFIX, suffix=".hdf")
         os.close(fd)

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -181,10 +181,7 @@ class ReturnnRasrDumpHDFJob(ReturnnDumpHDFJob):
         self.alignment = alignment
         self.rasr_exe = rasr.RasrCommand.select_exe(crp.nn_trainer_exe, "nn-trainer")
         self.feature_flow = ReturnnRasrTrainingJob.create_flow(feature_flow, alignment)
-        (
-            self.rasr_config,
-            self.rasr_post_config,
-        ) = ReturnnRasrTrainingJob.create_config(
+        (self.rasr_config, self.rasr_post_config,) = ReturnnRasrTrainingJob.create_config(
             crp=crp,
             alignment=alignment,
             num_classes=num_classes,

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -88,13 +88,12 @@ class ReturnnDumpHDFJob(Job):
         with open("dataset.config", "wt") as dataset_file:
             dataset_file.write("#!rnn.py\n")
             dataset_file.write("train = %s\n" % str(data))
-        self.data = "dataset.config"
 
     def run(self):
         if isinstance(self.data, tk.Path):
             data = self.data.get_path()
         else:
-            data = self.data
+            data = "dataset.config"
 
         (fd, tmp_hdf_file) = tempfile.mkstemp(prefix=gs.TMP_PREFIX, suffix=".hdf")
         os.close(fd)

--- a/tests/job_tests/returnn/test_dump.py
+++ b/tests/job_tests/returnn/test_dump.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+from typing import Optional
+
+from sisyphus import tk, setup_path
+
+from i6_core.returnn.hdf import ReturnnDumpHDFJob
+
+rel_path = setup_path(__package__)
+
+
+def test_hdf_dump():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from sisyphus import gs
+
+        gs.WORK_DIR = tmpdir
+        with open(f"{tmpdir}/tmp.config", 'wt') as f:
+            f.write("#!rnn.py\n")
+            f.write("train = {'class': 'DummyDataset', 'input_dim': 3, 'output_dim': 4, 'num_seqs': 2}")
+        data = rel_path(f"{tmpdir}/tmp.config")
+        job = ReturnnDumpHDFJob(data=data)
+        for task in ReturnnDumpHDFJob.tasks():
+            task()
+        

--- a/tests/job_tests/returnn/test_dump.py
+++ b/tests/job_tests/returnn/test_dump.py
@@ -19,18 +19,14 @@ def test_hdf_dump():
             f.write("#!rnn.py\n")
             f.write("train = {'class': 'DummyDataset', 'input_dim': 3, 'output_dim': 4, 'num_seqs': 2}")
         data = rel_path(f"{tmpdir}/tmp.config")
-        job = ReturnnDumpHDFJob(
-            data=data, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
-        )
+        job = ReturnnDumpHDFJob(data=data, returnn_root=tk.Path("returnn/"))
         assert [task.name() for task in job.tasks()] == ["run"]
         job._sis_setup_directory()
         job.run()
 
         # Case 2: dict
         data2 = {"class": "DummyDataset", "input_dim": 3, "output_dim": 4, "num_seqs": 2}
-        job2 = ReturnnDumpHDFJob(
-            data=data2, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
-        )
+        job2 = ReturnnDumpHDFJob(data=data2, returnn_root=tk.Path("returnn/"))
         assert [task.name() for task in job2.tasks()] == ["write_config", "run"]
         job2._sis_setup_directory()
         job2.write_config()
@@ -38,9 +34,7 @@ def test_hdf_dump():
 
         # Case 3: str
         data3 = "{'class': 'DummyDataset', 'input_dim': 3, 'output_dim': 4, 'num_seqs': 2}"
-        job3 = ReturnnDumpHDFJob(
-            data=data3, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
-        )
+        job3 = ReturnnDumpHDFJob(data=data3, returnn_root=tk.Path("returnn/"))
         assert [task.name() for task in job3.tasks()] == ["write_config", "run"]
         job3._sis_setup_directory()
         job3.write_config()

--- a/tests/job_tests/returnn/test_dump.py
+++ b/tests/job_tests/returnn/test_dump.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from typing import Optional
 
 from sisyphus import tk, setup_path
 
@@ -14,11 +13,41 @@ def test_hdf_dump():
         from sisyphus import gs
 
         gs.WORK_DIR = tmpdir
-        with open(f"{tmpdir}/tmp.config", 'wt') as f:
+
+        # Case 1: tk.Path
+        with open(f"{tmpdir}/tmp.config", "wt") as f:
             f.write("#!rnn.py\n")
             f.write("train = {'class': 'DummyDataset', 'input_dim': 3, 'output_dim': 4, 'num_seqs': 2}")
         data = rel_path(f"{tmpdir}/tmp.config")
-        job = ReturnnDumpHDFJob(data=data)
-        for task in ReturnnDumpHDFJob.tasks():
-            task()
-        
+        job = ReturnnDumpHDFJob(
+            data=data, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
+        )
+        assert [task.name() for task in job.tasks()] == ["run"]
+        job._sis_setup_directory()
+        job.run()
+
+        # Case 2: dict
+        data2 = {"class": "DummyDataset", "input_dim": 3, "output_dim": 4, "num_seqs": 2}
+        job2 = ReturnnDumpHDFJob(
+            data=data2, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
+        )
+        assert [task.name() for task in job2.tasks()] == ["write_config", "run"]
+        job2._sis_setup_directory()
+        job2.write_config()
+        job2.run()
+
+        # Case 3: str
+        data3 = "{'class': 'DummyDataset', 'input_dim': 3, 'output_dim': 4, 'num_seqs': 2}"
+        job3 = ReturnnDumpHDFJob(
+            data=data3, returnn_root=tk.Path("returnn/"), returnn_python_exe=tk.Path("/usr/bin/python3")
+        )
+        assert [task.name() for task in job3.tasks()] == ["write_config", "run"]
+        job3._sis_setup_directory()
+        job3.write_config()
+        job3.run()
+
+        assert os.path.getsize(job.out_hdf) == os.path.getsize(job2.out_hdf) == os.path.getsize(job3.out_hdf), (
+            os.path.getsize(job.out_hdf),
+            os.path.getsize(job2.out_hdf),
+            os.path.getsize(job3.out_hdf),
+        )


### PR DESCRIPTION
I had issues passing the string directly to the script when using this code via ReturnnRasrDumpHDFJob. Writing the dict into an explicit file and passing it helped.