### PR TITLE
Job to dump flow network

### DIFF
--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -409,3 +409,23 @@ def _smart_union(s, e):
     if type(e) == list or type(e) == set:
         return s.union(e)
     return s.union([e])
+
+
+class WriteFlowNetworkJob(Job):
+    """
+    Writes a flow network to a file
+    """
+
+    def __init__(
+        self,
+        flow: FlowNetwork,
+    ):
+        self.flow = flow
+
+        self.out_flow_file = self.output_path("network.flow")
+
+    def tasks(self):
+        yield Task("run", mini_task=True)
+
+    def run(self):
+        self.flow.write_to_file(self.out_flow_file.get_path())

--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -4,6 +4,7 @@ __all__ = [
     "NamedFlowAttribute",
     "FlagDependentFlowAttribute",
     "PathWithPrefixFlowAttribute",
+    "WriteFlowNetworkJob",
 ]
 
 import collections
@@ -12,6 +13,7 @@ import itertools as it
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as minidom
 
+from sisyphus import Job, Task
 from sisyphus.tools import extract_paths
 
 from .config import RasrConfig


### PR DESCRIPTION
A simple job that writes a `FlowNetwork` object to a file the way it is done in the `ReturnnRasrTrainingJob` for example. This would give one more freedom in training with the `ExternSprintDataset` without using `ReturnnRasrTrainingJob`, see also #165. When building the corresponding `RasrConfig` for training, it can be used as follows:
```
config.neural_network_trainer.feature_extraction.file = WriteFlowNetworkJob(feature_flow).out_flow_file
```