### PR TITLE
add verify step to apptek hash test

### DIFF
--- a/.github/workflows/apptek_hashes.yml
+++ b/.github/workflows/apptek_hashes.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         curl ${{ env.post_header }} ${{ env.auth_token}} ${{ env.api_url }} -d '${{ env.post_content }}'${GITHUB_HEAD_REF:-main}'"}]}' |\
         jq -r '.uuid' | sed 's/{/%7B/' | sed 's/}/%7D/' > pipeline_uuid.txt
+    - name: Verify Start
+      run: |
+        [ $(cat pipeline_uuid.txt) != "null" ]
     - name: Wait for Results
       run: |
         sleep 300


### PR DESCRIPTION
This PR adds a verify step to the AppTek test pipeline so that if the trigger fails, we do not waste build minutes on waiting for a result that never comes.