### PR TITLE
Add rec_step_by_step options to graph compilation

### DIFF
--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -21,7 +21,7 @@ class CompileTFGraphJob(Job):
 
     """
 
-    __sis_hash_exclude__ = {"device": None, "epoch": None}
+    __sis_hash_exclude__ = {"device": None, "epoch": None, "rec_step_by_step": None, "rec_json_info": False}
 
     def __init__(
         self,
@@ -36,6 +36,8 @@ class CompileTFGraphJob(Job):
         output_format="meta",
         returnn_python_exe=None,
         returnn_root=None,
+        rec_step_by_step=None,
+        rec_json_info=False,
     ):
         """
 
@@ -52,6 +54,8 @@ class CompileTFGraphJob(Job):
         :param str output_format: graph output format, one of ["pb", "pbtxt", "meta", "metatxt"]
         :param Optional[Path] returnn_python_exe: file path to the executable for running returnn (python binary or .sh)
         :param Optional[Path] returnn_root: file path to the RETURNN repository root folder
+        :param str|None rec_step_by_step: name of rec layer for step-by-step graph
+        :param bool rec_json_info: whether to enable rec json info for step-by-step graph compilation
         """
         self.returnn_config = returnn_config
         self.train = train
@@ -63,6 +67,8 @@ class CompileTFGraphJob(Job):
         self.summaries_tensor_name = summaries_tensor_name
         self.returnn_python_exe = util.get_returnn_python_exe(returnn_python_exe)
         self.returnn_root = util.get_returnn_root(returnn_root)
+        self.rec_step_by_step = rec_step_by_step
+        self.rec_json_info = rec_json_info
 
         self.out_graph = self.output_path("graph.%s" % output_format)
         self.out_model_params = self.output_var("model_params.pickle", pickle=True)
@@ -108,6 +114,10 @@ class CompileTFGraphJob(Job):
             args.append("--epoch=%d" % self.epoch)
         if self.summaries_tensor_name is not None:
             args.append("--summaries_tensor_name=%s" % self.summaries_tensor_name)
+        if self.rec_step_by_step is not None:
+            args.append(f"--rec_step_by_step={self.rec_step_by_step}")
+            if self.rec_json_info:
+                args.append("--rec_step_by_step_output_file=rec.info")
 
         util.create_executable("run.sh", args)
 

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -118,7 +118,7 @@ class CompileTFGraphJob(Job):
         if self.rec_step_by_step is not None:
             args.append(f"--rec_step_by_step={self.rec_step_by_step}")
             if self.rec_json_info:
-                args.append("--rec_step_by_step_output_file={self.out_rec_json_info.get()}")
+                args.append(f"--rec_step_by_step_output_file={self.out_rec_json_info.get_path()}")
 
         util.create_executable("run.sh", args)
 

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -74,7 +74,8 @@ class CompileTFGraphJob(Job):
         self.out_model_params = self.output_var("model_params.pickle", pickle=True)
         self.out_state_vars = self.output_var("state_vars.pickle", pickle=True)
         self.out_returnn_config = self.output_path("returnn.config")
-        self.out_rec_json_info = self.output_path("rec.info")
+        if self.rec_json_info:
+            self.out_rec_json_info = self.output_path("rec.info")
 
         self.rqmt = None
 

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -74,6 +74,7 @@ class CompileTFGraphJob(Job):
         self.out_model_params = self.output_var("model_params.pickle", pickle=True)
         self.out_state_vars = self.output_var("state_vars.pickle", pickle=True)
         self.out_returnn_config = self.output_path("returnn.config")
+        self.out_rec_json_info = self.output_path("rec.info")
 
         self.rqmt = None
 
@@ -117,7 +118,7 @@ class CompileTFGraphJob(Job):
         if self.rec_step_by_step is not None:
             args.append(f"--rec_step_by_step={self.rec_step_by_step}")
             if self.rec_json_info:
-                args.append("--rec_step_by_step_output_file=rec.info")
+                args.append("--rec_step_by_step_output_file={self.out_rec_json_info.get()}")
 
         util.create_executable("run.sh", args)
 

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -54,7 +54,7 @@ class CompileTFGraphJob(Job):
         :param str output_format: graph output format, one of ["pb", "pbtxt", "meta", "metatxt"]
         :param Optional[Path] returnn_python_exe: file path to the executable for running returnn (python binary or .sh)
         :param Optional[Path] returnn_root: file path to the RETURNN repository root folder
-        :param str|None rec_step_by_step: name of rec layer for step-by-step graph
+        :param Optional[str] rec_step_by_step: name of rec layer for step-by-step graph
         :param bool rec_json_info: whether to enable rec json info for step-by-step graph compilation
         """
         self.returnn_config = returnn_config


### PR DESCRIPTION
Add option to specify `rec_step_by_step` layer in `CompileTFGraphJob`. This option is used to compile encoder-decoder models such as RNN-T.