### PR TITLE
Adjustment to the RasrAlignmentDumpHDFJob 

### DIFF
--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -1,6 +1,7 @@
 __all__ = ["ReturnnDumpHDFJob", "ReturnnRasrDumpHDFJob", "BlissToPcmHDFJob", "RasrAlignmentDumpHDFJob"]
 
 from dataclasses import dataclass
+import glob
 import numpy as np
 import os
 import shutil
@@ -323,7 +324,8 @@ class RasrAlignmentDumpHDFJob(Job):
 
     def merge(self):
         excluded_segments = []
-        for p in self.excluded_segment_sublists:
+        excluded_files = glob.glob("excluded_segments.*")
+        for p in excluded_files:
             if os.path.isfile(p):
                 with open(p, "r") as f:
                     segments = f.read().splitlines()
@@ -371,4 +373,4 @@ class RasrAlignmentDumpHDFJob(Job):
         out_hdf.close()
 
         if len(excluded_segments):
-            write_paths_to_file(self.excluded_segment_sublists[task_id - 1], excluded_segments)
+            write_paths_to_file(f"excluded_segments.{task_id}", excluded_segments)

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -309,7 +309,7 @@ class RasrAlignmentDumpHDFJob(Job):
         self.alignment_caches = alignment_caches
         self.allophone_file = allophone_file
         self.state_tying_file = state_tying_file
-        self.out_hdf_files = [self.output_path(f"data.hdf.{d}", cached=False) for d in range(len(alignment_caches))]
+        self.out_hdf_files = [self.output_path(f"data.hdf.{d}") for d in range(len(alignment_caches))]
         self.out_excluded_segments = self.output_path(f"excluded.segments", cached=False)
         self.returnn_root = returnn_root
         self.data_type = data_type

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -310,7 +310,7 @@ class RasrAlignmentDumpHDFJob(Job):
         self.allophone_file = allophone_file
         self.state_tying_file = state_tying_file
         self.out_hdf_files = [self.output_path(f"data.hdf.{d}") for d in range(len(alignment_caches))]
-        self.out_excluded_segments = self.output_path(f"excluded.segments", cached=False)
+        self.out_excluded_segments = self.output_path(f"excluded.segments")
         self.returnn_root = returnn_root
         self.data_type = data_type
         self.rqmt = {"cpu": 1, "mem": 8, "time": 0.5}

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -310,9 +310,6 @@ class RasrAlignmentDumpHDFJob(Job):
         self.allophone_file = allophone_file
         self.state_tying_file = state_tying_file
         self.out_hdf_files = [self.output_path(f"data.hdf.{d}", cached=False) for d in range(len(alignment_caches))]
-        self.excluded_segment_sublists = [
-            self.output_path(f"excluded.segments.{d}", cached=False) for d in range(len(alignment_caches))
-        ]
         self.out_excluded_segments = self.output_path(f"excluded.segments", cached=False)
         self.returnn_root = returnn_root
         self.data_type = data_type

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -309,9 +309,7 @@ class RasrAlignmentDumpHDFJob(Job):
         self.allophone_file = allophone_file
         self.state_tying_file = state_tying_file
         self.out_hdf_files = [self.output_path(f"data.hdf.{d}", cached=False) for d in range(len(alignment_caches))]
-        self.out_excluded_segments = [
-            self.output_path(f"excluded_segments.cache.{d}", cached=False) for d in range(len(alignment_caches))
-        ]
+        self.out_excluded_segments = self.output_path(f"excluded.segments", cached=False)
         self.returnn_root = returnn_root
         self.data_type = data_type
         self.rqmt = {"cpu": 1, "mem": 8, "time": 0.5}
@@ -320,7 +318,8 @@ class RasrAlignmentDumpHDFJob(Job):
         yield Task("run", rqmt=self.rqmt, args=range(1, (len(self.alignment_caches) + 1)))
 
     def _write_text(self, path, segment_list):
-        with open(path, "w") as f:
+        write_flag = "a" if os.path.isfile(path) else "w"
+        with open(path, write_flag) as f:
             for item in segment_list:
                 f.write("%s\n" % item)
 
@@ -363,5 +362,4 @@ class RasrAlignmentDumpHDFJob(Job):
 
         out_hdf.close()
 
-        if len(excluded_segments):
-            self._write_text(self.out_excluded_segments[task_id - 1], excluded_segments)
+        self._write_text(self.out_excluded_segments, excluded_segments)


### PR DESCRIPTION
If an alignment is empty now we skip that segment and output the name of that segment in an output file.