### PR TITLE
BlissToOggZipJob: delete at end of merge task

### DIFF
--- a/returnn/oggzip.py
+++ b/returnn/oggzip.py
@@ -138,7 +138,6 @@ class BlissToOggZipJob(Job):
             for zip_subarchive in self.zip_subarchives.hidden_paths.values():
                 with zipfile.ZipFile(zip_subarchive, mode="r", compression=zipfile.ZIP_DEFLATED) as zip_file:
                     zip_file.extractall(tmp_dir)
-                os.remove(zip_subarchive)
 
             # create output folder
             assert self.out_ogg_zip.get().endswith(".zip")
@@ -191,7 +190,10 @@ class BlissToOggZipJob(Job):
                         print("Adding:", zip_path)
                         zip_file.write(path, zip_path)
 
+            # move final output and delete single subarchives
             shutil.move(zip_file.filename, self.out_ogg_zip.get())
+            for zip_subarchive in self.zip_subarchives.hidden_paths.values():
+                os.remove(zip_subarchive)
 
     @classmethod
     def hash(cls, parsed_args):


### PR DESCRIPTION
I ran into an issue where the merge task crashed (`rsync` which is used in the task was not installed on the node, but does not really matter here). Unfortunately, the single zip files in the work folder are deleted right at the beginning of the merge task so I had to recreate all of them instead of just rerunning the merge task. I therefore propose to delete them only at the end of the merge task.