### PR TITLE
GMM: Add Wer to output if available

### DIFF
--- a/meta/system.py
+++ b/meta/system.py
@@ -662,6 +662,8 @@ class System:
 
         self.jobs[corpus]["scorer_%s" % name] = scorer
         tk.register_output("%srecog_%s.reports" % (prefix, name), scorer.out_report_dir)
+        if scorer.out_wer:
+            tk.register_output("%s/wers/recog_%s.wer" % (prefix, name), scorer.out_wer)
 
     def optimize_am_lm(self, name, corpus, initial_am_scale, initial_lm_scale, prefix="", **kwargs):
         """


### PR DESCRIPTION
Currently the report directory is added to the output, where a report has to be opened and the WER read from there. At least for the scorers I am using, usually there also is `.out_wer` available. 
To not flood the folder too much I put it in a subfolder. Maybe we can even think of moving logs and reports to a folder too?