### PR TITLE
Add ffmpeg_input_options to BlissFfmpegJob

### DIFF
--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -1,0 +1,2 @@
+from .encoding import *
+from .ffmpeg import *

--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -13,8 +13,8 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
 
     __sis_hash_exclude__ = {
         "recover_duration": None,
-        "in_codec": None,
-        "in_codec_options": None,
+        "input_codec": None,
+        "input_codec_options": None,
     }
 
     def __init__(

--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -1,8 +1,9 @@
 __all__ = ["BlissChangeEncodingJob"]
 
-from sisyphus import Path
+from typing import List, Optional, Tuple, Union
 
 from i6_core.audio.ffmpeg import BlissFfmpegJob
+from sisyphus import tk
 
 
 class BlissChangeEncodingJob(BlissFfmpegJob):
@@ -10,52 +11,60 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
     Uses ffmpeg to convert all audio files of a bliss corpus (file format, encoding, channel layout)
     """
 
-    __sis_hash_exclude__ = {"recover_duration": None}
+    __sis_hash_exclude__ = {
+        "recover_duration": None,
+        "in_codec": None,
+        "in_codec_options": None,
+    }
 
     def __init__(
         self,
-        corpus_file,
-        output_format,
-        sample_rate=None,
-        codec=None,
-        codec_options=None,
-        fixed_bitrate=None,
-        force_num_channels=None,
-        select_channels=None,
-        ffmpeg_binary=None,
-        hash_binary=False,
-        recover_duration=None,
+        corpus_file: tk.Path,
+        output_format: Optional[str],
+        sample_rate: Optional[int] = None,
+        codec: Optional[str] = None,
+        codec_options: Optional[List[str]] = None,
+        fixed_bitrate: Optional[Union[str, int]] = None,
+        force_num_channels: Optional[int] = None,
+        select_channels: Optional[Tuple[str, str]] = None,
+        ffmpeg_binary: Optional[tk.Path] = None,
+        hash_binary: bool = False,
+        recover_duration: Optional[bool] = None,
+        in_codec: Optional[str] = None,
+        in_codec_options: Optional[List[str]] = None,
     ):
         """
         For all parameter holds that "None" means to use the ffmpeg defaults, which depend on the input file
         and the output format specified.
 
-        :param Path corpus_file: bliss corpus
-        :param str|None output_format: output file ending to determine container format (without dot)
-        :param int|None sample_rate: target sample rate of the audio
-        :param str|None codec: specify the codec, codecs are listed with `ffmpeg -codecs`
-        :param list(str)|None codec_options: specify additional codec specific options
+        :param corpus_file: bliss corpus
+        :param output_format: output file ending to determine container format (without dot)
+        :param sample_rate: target sample rate of the audio
+        :param codec: specify the codec, codecs are listed with `ffmpeg -codecs`
+        :param codec_options: specify additional codec specific options
             (be aware of potential conflicts with "fixed bitrate" and "sample_rate")
-        :param int|str|None: fixed_bitrate: a target bitrate (be aware that not all codecs support all bitrates)
-        :param int|None force_num_channels: specify the channel number, exceeding channels will be merged
-        :param tuple(str)|None select_channels: tuple of (channel_layout, channel_name), see `ffmpeg -layouts`
+        :param fixed_bitrate: a target bitrate (be aware that not all codecs support all bitrates)
+        :param force_num_channels: specify the channel number, exceeding channels will be merged
+        :param select_channels: tuple of (channel_layout, channel_name), see `ffmpeg -layouts`
             this is useful if the new encoding might have an effect on the duration, or if no duration was specified
             in the source corpus
-        :param Path|str|None ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
-        :param bool hash_binary: In some cases it might be required to work with a specific ffmpeg version,
+        :param ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
+        :param hash_binary: In some cases it might be required to work with a specific ffmpeg version,
                                  in which case the binary needs to be hashed
-        :param bool|None recover_duration: This will open all files with "soundfile" and extract the length information.
+        :param recover_duration: This will open all files with "soundfile" and extract the length information.
             There might be minimal differences when converting the encoding, so only set this to `False` if you're
             willing to accept this risk. `None` (default) means that the duration is recovered if either `output_format`
             or `codec` is specified because this might possibly lead to duration mismatches.
         """
+        ffmpeg_in_options = []
         ffmpeg_options = []
 
         if select_channels:
             assert isinstance(select_channels, tuple) and len(select_channels) == 2
             ffmpeg_options += [
                 "-filter_complex",
-                "[0:a]channelsplit=channel_layout=%s:channels=%s[out]" % select_channels,
+                "[0:a]channelsplit=channel_layout=%s:channels=%s[out]"
+                % select_channels,
                 "-map",
                 "[out]",
             ]
@@ -64,6 +73,12 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
 
         if codec_options:
             ffmpeg_options += codec_options
+
+        if in_codec:
+            ffmpeg_in_options += ["-c:a", in_codec]
+
+        if in_codec_options:
+            ffmpeg_in_options += in_codec_options
 
         if fixed_bitrate:
             ffmpeg_options += ["-b:a", str(fixed_bitrate)]
@@ -82,6 +97,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
 
         super().__init__(
             corpus_file=corpus_file,
+            ffmpeg_in_options=ffmpeg_in_options,
             ffmpeg_options=ffmpeg_options,
             recover_duration=recover_duration,
             output_format=output_format,

--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -55,6 +55,8 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
             There might be minimal differences when converting the encoding, so only set this to `False` if you're
             willing to accept this risk. `None` (default) means that the duration is recovered if either `output_format`
             or `codec` is specified because this might possibly lead to duration mismatches.
+        :param in_codec: specify the codec of the input file
+        :param in_codec_options: specify additional codec specific options for the in_codec
         """
         ffmpeg_in_options = []
         ffmpeg_options = []
@@ -63,8 +65,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
             assert isinstance(select_channels, tuple) and len(select_channels) == 2
             ffmpeg_options += [
                 "-filter_complex",
-                "[0:a]channelsplit=channel_layout=%s:channels=%s[out]"
-                % select_channels,
+                "[0:a]channelsplit=channel_layout=%s:channels=%s[out]" % select_channels,
                 "-map",
                 "[out]",
             ]

--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -30,8 +30,8 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         ffmpeg_binary: Optional[tk.Path] = None,
         hash_binary: bool = False,
         recover_duration: Optional[bool] = None,
-        in_codec: Optional[str] = None,
-        in_codec_options: Optional[List[str]] = None,
+        input_codec: Optional[str] = None,
+        input_codec_options: Optional[List[str]] = None,
     ):
         """
         For all parameter holds that "None" means to use the ffmpeg defaults, which depend on the input file
@@ -58,7 +58,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         :param in_codec: specify the codec of the input file
         :param in_codec_options: specify additional codec specific options for the in_codec
         """
-        ffmpeg_in_options = []
+        ffmpeg_input_options = []
         ffmpeg_options = []
 
         if select_channels:
@@ -75,11 +75,11 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         if codec_options:
             ffmpeg_options += codec_options
 
-        if in_codec:
-            ffmpeg_in_options += ["-c:a", in_codec]
+        if input_codec:
+            ffmpeg_input_options += ["-c:a", input_codec]
 
-        if in_codec_options:
-            ffmpeg_in_options += in_codec_options
+        if input_codec_options:
+            ffmpeg_input_options += input_codec_options
 
         if fixed_bitrate:
             ffmpeg_options += ["-b:a", str(fixed_bitrate)]
@@ -98,7 +98,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
 
         super().__init__(
             corpus_file=corpus_file,
-            ffmpeg_in_options=ffmpeg_in_options,
+            ffmpeg_input_options=ffmpeg_input_options,
             ffmpeg_options=ffmpeg_options,
             recover_duration=recover_duration,
             output_format=output_format,

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -4,10 +4,10 @@ import copy
 import logging
 import os
 import subprocess
-
-from sisyphus import *
+from typing import List, Optional, Union
 
 from i6_core.lib import corpus
+from sisyphus import Job, Task, tk
 
 
 class BlissFfmpegJob(Job):
@@ -70,27 +70,31 @@ class BlissFfmpegJob(Job):
 
     """
 
+    __sis_hash_exclude__ = {"ffmpeg_in_options": None}
+
     def __init__(
         self,
-        corpus_file,
-        ffmpeg_options=None,
-        recover_duration=True,
-        output_format=None,
-        ffmpeg_binary=None,
-        hash_binary=False,
+        corpus_file: tk.Path,
+        ffmpeg_options: Optional[List[str]] = None,
+        recover_duration: bool = True,
+        output_format: Optional[str] = None,
+        ffmpeg_binary: Optional[Union[str, tk.Path]] = None,
+        hash_binary: bool = False,
+        ffmpeg_in_options: Optional[List[str]] = None,
     ):
         """
 
-        :param Path corpus_file: bliss corpus
-        :param list(str)|None ffmpeg_options: list of additional ffmpeg parameters
-        :param bool recover_duration: if the filter changes the duration of the audio, set to True
-        :param str output_format: output file ending to determine container format (without dot)
-        :param Path|str|None ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
-        :param bool hash_binary: In some cases it might be required to work with a specific ffmpeg version,
-                                 in which case the binary needs to be hashed
+        :param corpus_file: bliss corpus
+        :param ffmpeg_options: list of additional ffmpeg parameters
+        :param recover_duration: if the filter changes the duration of the audio, set to True
+        :param output_format: output file ending to determine container format (without dot)
+        :param ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
+        :param hash_binary: In some cases it might be required to work with a specific ffmpeg version,
+                            in which case the binary needs to be hashed
 
         """
         self.corpus_file = corpus_file
+        self.ffmpeg_in_options = ffmpeg_in_options
         self.ffmpeg_options = ffmpeg_options
         self.recover_duration = recover_duration
         self.output_format = output_format
@@ -141,15 +145,19 @@ class BlissFfmpegJob(Job):
 
         for r in c.all_recordings():
             assert len(r.segments) == 1, "needs to be a single segment recording"
-            old_duration = r.segments[0].end
+            segment = r.segments[0]
+            old_duration = segment.end
+            assert r.audio is not None
             data, sample_rate = soundfile.read(open(r.audio, "rb"))
             new_duration = len(data) / sample_rate
-            logging.info("%s: adjusted from %f to %f seconds" % (r.segments[0].name, old_duration, new_duration))
-            r.segments[0].end = new_duration
+            logging.info(
+                f"{segment.name}: adjusted from {old_duration} to {new_duration} seconds"
+            )
+            segment.end = new_duration
 
         c.dump(self.out_corpus.get_path())
 
-    def _get_output_filename(self, recording):
+    def _get_output_filename(self, recording: corpus.Recording):
         """
         returns a new audio filename with a potentially
         changed file ending based on "output_format"
@@ -158,13 +166,14 @@ class BlissFfmpegJob(Job):
         :return:
         :rtype str
         """
+        assert recording.audio is not None
         audio_filename = os.path.basename(recording.audio)
         if self.output_format is not None:
-            name, ext = os.path.splitext(audio_filename)
+            name, _ = os.path.splitext(audio_filename)
             audio_filename = name + "." + self.output_format
         return audio_filename
 
-    def _perform_ffmpeg(self, recording):
+    def _perform_ffmpeg(self, recording: corpus.Recording):
         """
         Build and call an FFMPEG command to apply on a recording
 
@@ -175,22 +184,22 @@ class BlissFfmpegJob(Job):
 
         target = os.path.join(self.out_audio_folder.get_path(), audio_filename)
         if not os.path.exists(target):
-            logging.info("try converting %s" % target)
+            logging.info(f"try converting {target}")
             command_head = [
                 self.ffmpeg_binary,
                 "-hide_banner",
                 "-y",
-                "-i",
-                recording.audio,
             ]
-            command_tail = [os.path.join(self.out_audio_folder.get_path(), audio_filename)]
-            if self.ffmpeg_options is None or len(self.ffmpeg_options) == 0:
-                command = command_head + command_tail
-            else:
-                command = command_head + self.ffmpeg_options + command_tail
+            command_in = ["-i", recording.audio]
+            command_out = [
+                os.path.join(self.out_audio_folder.get_path(), audio_filename),
+            ]
+            in_options = self.ffmpeg_in_options or []
+            out_options = self.ffmpeg_options or []
+            command = command_head + in_options + command_in + out_options + command_out
             subprocess.check_call(command)
         else:
-            logging.info("skipped existing %s" % target)
+            logging.info(f"skipped existing {target}")
 
     @classmethod
     def hash(cls, kwargs):

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -80,7 +80,7 @@ class BlissFfmpegJob(Job):
         output_format: Optional[str] = None,
         ffmpeg_binary: Optional[Union[str, tk.Path]] = None,
         hash_binary: bool = False,
-        ffmpeg_in_options: Optional[List[str]] = None,
+        ffmpeg_input_options: Optional[List[str]] = None,
     ):
         """
 
@@ -91,10 +91,10 @@ class BlissFfmpegJob(Job):
         :param ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
         :param hash_binary: In some cases it might be required to work with a specific ffmpeg version,
                             in which case the binary needs to be hashed
-        :param ffmpeg_in_options: list of ffmpeg parameters thare are applied for reading the input files
+        :param ffmpeg_input_options: list of ffmpeg parameters thare are applied for reading the input files
         """
         self.corpus_file = corpus_file
-        self.ffmpeg_in_options = ffmpeg_in_options
+        self.ffmpeg_input_options = ffmpeg_input_options
         self.ffmpeg_options = ffmpeg_options
         self.recover_duration = recover_duration
         self.output_format = output_format
@@ -192,7 +192,7 @@ class BlissFfmpegJob(Job):
             command_out = [
                 os.path.join(self.out_audio_folder.get_path(), audio_filename),
             ]
-            in_options = self.ffmpeg_in_options or []
+            in_options = self.ffmpeg_input_options or []
             out_options = self.ffmpeg_options or []
             command = command_head + in_options + command_in + out_options + command_out
             subprocess.check_call(command)

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -70,7 +70,7 @@ class BlissFfmpegJob(Job):
 
     """
 
-    __sis_hash_exclude__ = {"ffmpeg_in_options": None}
+    __sis_hash_exclude__ = {"ffmpeg_input_options": None}
 
     def __init__(
         self,

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -91,7 +91,7 @@ class BlissFfmpegJob(Job):
         :param ffmpeg_binary: path to a ffmpeg binary, uses system "ffmpeg" if None
         :param hash_binary: In some cases it might be required to work with a specific ffmpeg version,
                             in which case the binary needs to be hashed
-
+        :param ffmpeg_in_options: list of ffmpeg parameters thare are applied for reading the input files
         """
         self.corpus_file = corpus_file
         self.ffmpeg_in_options = ffmpeg_in_options
@@ -150,9 +150,7 @@ class BlissFfmpegJob(Job):
             assert r.audio is not None
             data, sample_rate = soundfile.read(open(r.audio, "rb"))
             new_duration = len(data) / sample_rate
-            logging.info(
-                f"{segment.name}: adjusted from {old_duration} to {new_duration} seconds"
-            )
+            logging.info(f"{segment.name}: adjusted from {old_duration} to {new_duration} seconds")
             segment.end = new_duration
 
         c.dump(self.out_corpus.get_path())


### PR DESCRIPTION
Currently, the `BlissFfmpegJob` only accepts ffmpeg options for the output file. This was an issue when I tried to perform a `BlissChangeEncodingJob` but ffmpeg was not able to read the input files without specifying the correct codec.

This PR adds an `ffmpeg_in_options` parameter to the `BlissFfmpegJob` such that these options are applied when reading an input file. Also, `in_codec` and `in_codec_options` where added to the `BlissChangeEncodingJob` which directly utilize the new `ffmpeg_in_options`.

While we're touching these files, I also added type hints everywhere.