### PR TITLE
Gracefully handle transient FileExistsError

### DIFF
--- a/returnn/training.py
+++ b/returnn/training.py
@@ -231,6 +231,8 @@ class ReturnnTrainingJob(Job):
             try:
                 with open(file_path, "rt") as file:
                     return eval(file.read().strip())
+            except FileExistsError:
+                return None
             except FileNotFoundError:
                 return None
 


### PR DESCRIPTION
Since Ubuntu 22 my sisyphus manager has been crashing occasionally w/ the following obscure error while trying to read the learning rates file to show training progress:
![Bildschirmfoto 2023-05-22 um 11 57 40](https://github.com/rwth-i6/i6_core/assets/1683034/cab6df1d-7092-41f8-8565-c378c9242b3b)

The error does not make a lot of sense as it is trying to open the file in read mode (so why is it complaining the file exists?!), but it is transient and usually does not happen again after a short while when the sisyphus manager is restarted. We can therefore just ignore it and wait until the job info is computed the next time.

Feel free to merge if you're the one doing the second approval.