### PR TITLE
Output WER to relpath instead of to abspath

### DIFF
--- a/meta/system.py
+++ b/meta/system.py
@@ -721,7 +721,7 @@ class System:
         self.jobs[corpus]["scorer_%s" % name] = scorer
         tk.register_output("%srecog_%s.reports" % (prefix, name), scorer.out_report_dir)
         if scorer.out_wer:
-            tk.register_output("%s/wers/recog_%s.wer" % (prefix, name), scorer.out_wer)
+            tk.register_output("%swers/recog_%s.wer" % (prefix, name), scorer.out_wer)
 
     def optimize_am_lm(
         self, name: str, corpus: str, initial_am_scale: float, initial_lm_scale: float, prefix: str = "", **kwargs


### PR DESCRIPTION
When `prefix=""`, the output was being written to `/wers/...`, which is undesirable since `/wers` is outside of the recipe. With this change, we ensure that the output is always correctly written to the relative path `output/wers/...`.

Note that for `prefix` to work correctly it needs to be a directory, i.e. it needs to finish with `/`, but I think that's a precondition that's already set two lines above, when setting more outputs to `{prefix}recog_...`