### PR TITLE
help for port names in generic_features

### DIFF
--- a/meta/system.py
+++ b/meta/system.py
@@ -382,11 +382,14 @@ class System:
         :param corpus: corpus identifier
         :param name: feature identifier, like "mfcc". Also used in the naming of the output feature caches.
         :param feature_flow: definition of the RASR feature flow network
-        :param port_name: output port of the flow network to use
+        :param port_name: output port of the flow network to use, e.g., for samples_flow() this is "samples"
         :param prefix: prefix for the alias job symlink
         :param kwargs:
         :return:
         """
+        assert (
+            port_name in feature_flow.outputs
+        ), f"port name '{port_name}' not available in feature flow (available are: {feature_flow.outputs})"
         port_name_mapping = {port_name: name}
         self.jobs[corpus][f"{name}_features"] = f = features.FeatureExtractionJob(
             self.crp[corpus], feature_flow, port_name_mapping, job_name=name, **kwargs


### PR DESCRIPTION
Recently, I wanted to extract features with the samples feature flow to have cached files with waveforms that can be used in recognition.
```
flow = samples_flow(dc_detection=False, input_options={"block-size": "1"}, scale_input=2**-15)
system.extract_features(
    feat_args={"samples": {"feature_flow": flow, "port_name": "samples"}},
    corpus_list=system.dev_corpora + system.test_corpora,
)
```

It took me quite a while to figure out that I need this `"port_name": "samples"` because otherwise the cached feature flow for the feature extraction job is not built correctly. I added a comment in the docstring with this example. Also, I added an assertion which helps the user by checking this during graph creation already (before, the job failed at runtime). I'm not entirely sure though if my understanding of the flow creation is correct and this assertion is intended in all cases. Maybe @curufinwe or @michelwi know this? Let's also see if this affects the checks here.