### PR TITLE
ComputePriorJob remove network assert

### DIFF
--- a/returnn/extract_prior.py
+++ b/returnn/extract_prior.py
@@ -215,7 +215,6 @@ class ReturnnComputePriorJobV2(Job):
         """
         assert device in ["gpu", "cpu"]
         original_config = returnn_config.config
-        assert "network" in original_config
 
         config = copy.deepcopy(original_config)
         config["load"] = model_checkpoint


### PR DESCRIPTION
This change was done similarly for the returnn training job since e.g. returnn frontend does not always have a network definition in the config anymore. 