### PR TITLE
explicitly set *_NUM_THREADS in Returnn run

### DIFF
--- a/returnn/extract_prior.py
+++ b/returnn/extract_prior.py
@@ -163,7 +163,10 @@ class ReturnnComputePriorJobV2(Job):
 
     def run(self):
         cmd = self._get_run_cmd()
-        sp.check_call(cmd)
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = str(self.rqmt["cpu"])
+        env["MKL_NUM_THREADS"] = str(self.rqmt["cpu"])
+        sp.check_call(cmd, env=env)
 
         merged_scores = np.loadtxt(self.out_prior_txt_file.get_path(), delimiter=" ")
 

--- a/returnn/forward.py
+++ b/returnn/forward.py
@@ -124,7 +124,10 @@ class ReturnnForwardJob(Job):
             ]
 
             try:
-                sp.check_call(call, cwd=d)
+                env = os.environ.copy()
+                env["OMP_NUM_THREADS"] = str(self.rqmt["cpu"])
+                env["MKL_NUM_THREADS"] = str(self.rqmt["cpu"])
+                sp.check_call(call, cwd=d, env=env)
             except Exception as e:
                 print("Run crashed - copy temporary work folder as 'crash_dir'")
                 shutil.copytree(d, "crash_dir")

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -127,7 +127,10 @@ class ReturnnSearchJobV2(Job):
             os.path.join(self.returnn_root.get_path(), "rnn.py"),
             self.out_returnn_config_file.get_path(),
         ]
-        sp.check_call(call)
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = str(self.rqmt["cpu"])
+        env["MKL_NUM_THREADS"] = str(self.rqmt["cpu"])
+        sp.check_call(call, env=env)
 
     @classmethod
     def create_returnn_config(

--- a/returnn/training.py
+++ b/returnn/training.py
@@ -352,7 +352,10 @@ class ReturnnTrainingJob(Job):
                         print("Cannot read:", exc)
             sys.stdout.flush()
 
-        sp.check_call(self._get_run_cmd())
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = str(self.rqmt["cpu"])
+        env["MKL_NUM_THREADS"] = str(self.rqmt["cpu"])
+        sp.check_call(self._get_run_cmd(), env=env)
 
         lrf = self.returnn_config.get("learning_rate_file", "learning_rates")
         self._relink(lrf, self.out_learning_rates.get_path())


### PR DESCRIPTION
now that we are using e.g. Apptainer and no external run shell scripts (launcher), I think it is better when the Job itself already sets the variables correctly to the amount of reserved CPU threads. In case you are using a launcher script, you can still overwrite these values as before.