### PR TITLE
returnn init: add search

### DIFF
--- a/returnn/__init__.py
+++ b/returnn/__init__.py
@@ -5,4 +5,5 @@ from .forward import *
 from .hdf import *
 from .oggzip import *
 from .rasr_training import *
+from .search import *
 from .training import *


### PR DESCRIPTION
In a number of setups, we do something like
```
import i6_core.returnn as returnn

config = returnn.ReturnnConfig(...)
train_job = returnn.ReturnnTrainingJob(...)
```
I'd like to do the same for the search jobs, so added search to the init file.