### PR TITLE
Add option for external lmgc scorer

### DIFF
--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -146,7 +146,7 @@ class AdvancedTreeSearchLmImageAndGlobalCacheJob(rasr.RasrCommand, Job):
     def hash(cls, kwargs):
         config, post_config, num_images = cls.create_config(**kwargs)
         return super().hash(
-            {"config": config, "exe": kwargs["crp"].flf_tool_exe, "post_config": post_config},
+            {"config": config, "exe": kwargs["crp"].flf_tool_exe},
         )
 
 

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -145,7 +145,9 @@ class AdvancedTreeSearchLmImageAndGlobalCacheJob(rasr.RasrCommand, Job):
     @classmethod
     def hash(cls, kwargs):
         config, post_config, num_images = cls.create_config(**kwargs)
-        return super().hash({"config": config, "exe": kwargs["crp"].flf_tool_exe})
+        return super().hash(
+            {"config": config, "exe": kwargs["crp"].flf_tool_exe, "post_config": post_config},
+        )
 
 
 class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
@@ -166,6 +168,7 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         cpu: int = 1,
         lmgc_mem: float = 12.0,
         lmgc_alias: Optional[str] = None,
+        lmgc_scorer: Optional[rasr.FeatureScorer] = None,
         model_combination_config: Optional[rasr.RasrConfig] = None,
         model_combination_post_config: Optional[rasr.RasrConfig] = None,
         extra_config: Optional[rasr.RasrConfig] = None,
@@ -188,6 +191,7 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         :param cpu: CPU requirement for the job
         :param lmgc_mem: Memory requirement for the AdvancedTreeSearchLmImageAndGlobalCacheJob
         :param lmgc_alias: Alias for the AdvancedTreeSearchLmImageAndGlobalCacheJob
+        :param lmgc_scorer: Dummy scorer for the AdvancedTreeSearchLmImageAndGlobalCacheJob which is required but unused
         :param model_combination_config: Configuration for model combination
         :param model_combination_post_config: Post config for model combination
         :param extra_config: Additional Config for recognition
@@ -283,13 +287,16 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         cpu: int,
         lmgc_mem: float,
         lmgc_alias: Union[None, str],
+        lmgc_scorer: Union[None, rasr.FeatureScorer],
         model_combination_config: Union[None, rasr.RasrConfig],
         model_combination_post_config: Union[None, rasr.RasrConfig],
         extra_config: Union[None, rasr.RasrConfig],
         extra_post_config: Union[None, rasr.RasrConfig],
         **kwargs,
     ):
-        lm_gc = AdvancedTreeSearchLmImageAndGlobalCacheJob(crp, feature_scorer, extra_config, extra_post_config)
+        lm_gc = AdvancedTreeSearchLmImageAndGlobalCacheJob(
+            crp, lmgc_scorer if lmgc_scorer is not None else feature_scorer, extra_config, extra_post_config
+        )
         if lmgc_alias is not None:
             lm_gc.add_alias(lmgc_alias)
         lm_gc.rqmt["mem"] = lmgc_mem

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -13,7 +13,7 @@ Path = setup_path(__package__)
 import math
 import os
 import shutil
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 import i6_core.lm as lm
 import i6_core.rasr as rasr
@@ -275,21 +275,21 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         crp: rasr.CommonRasrParameters,
         feature_flow: rasr.FlowNetwork,
         feature_scorer: rasr.FeatureScorer,
-        search_parameters: Union[None, Dict[str, Any]],
+        search_parameters: Optional[Dict[str, Any]],
         lm_lookahead: bool,
-        lookahead_options: Union[None, Dict[str, Any]],
+        lookahead_options: Optional[Dict[str, Any]],
         create_lattice: bool,
         eval_single_best: bool,
         eval_best_in_lattice: bool,
         mem: float,
         cpu: int,
         lmgc_mem: float,
-        lmgc_alias: Union[None, str],
-        lmgc_scorer: Union[None, rasr.FeatureScorer],
-        model_combination_config: Union[None, rasr.RasrConfig],
-        model_combination_post_config: Union[None, rasr.RasrConfig],
-        extra_config: Union[None, rasr.RasrConfig],
-        extra_post_config: Union[None, rasr.RasrConfig],
+        lmgc_alias: Optional[str],
+        lmgc_scorer: Optional[rasr.FeatureScorer],
+        model_combination_config: Optional[rasr.RasrConfig],
+        model_combination_post_config: Optional[rasr.RasrConfig],
+        extra_config: Optional[rasr.RasrConfig],
+        extra_post_config: Optional[rasr.RasrConfig],
         **kwargs,
     ):
         lm_gc = AdvancedTreeSearchLmImageAndGlobalCacheJob(

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -145,9 +145,7 @@ class AdvancedTreeSearchLmImageAndGlobalCacheJob(rasr.RasrCommand, Job):
     @classmethod
     def hash(cls, kwargs):
         config, post_config, num_images = cls.create_config(**kwargs)
-        return super().hash(
-            {"config": config, "exe": kwargs["crp"].flf_tool_exe},
-        )
+        return super().hash({"config": config, "exe": kwargs["crp"].flf_tool_exe})
 
 
 class AdvancedTreeSearchJob(rasr.RasrCommand, Job):


### PR DESCRIPTION
This adds the option to add a dummy scorer as external input to the LMGC Job. Similar to the alias update in #419 this should not change hashes. 

Since the scorer is not used but still required it can be fed with smth. like: 
```
acoustic_mixture_path = CreateDummyMixturesJob(
    num_mixtures=returnn_config.config['extern_data']['classes']['dim'],
    num_features=returnn_config.config['extern_data']['data']['dim']).out_mixtures
lmgc_scorer = rasr.GMMFeatureScorer(acoustic_mixture_path)
```
