### PR TITLE
lexicon init: add modification

### DIFF
--- a/lexicon/__init__.py
+++ b/lexicon/__init__.py
@@ -2,3 +2,4 @@ from .allophones import *
 from .beep import *
 from .cmu import *
 from .conversion import *
+from .modification import *


### PR DESCRIPTION
All files except `modification.py` are included in `lexicon/__init__.py`. I'd like to add it for consistency.