### PR TITLE
Add OnnxExportJob

### DIFF
--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -216,6 +216,7 @@ class OnnxExportJob(Job):
 
     def __init__(
         self,
+        *,
         returnn_config: ReturnnConfig,
         checkpoint: Union[Checkpoint, PtCheckpoint],
         device: str = "cpu",

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -209,8 +209,11 @@ class CompileNativeOpJob(Job):
 
 class OnnxExportJob(Job):
     """
-    
+        Export an ONNX model using the appropriate RETURNN tool script.
+
+        Currently only supports PyTorch via tools/torch_export_to_onnx.py
     """
+
     def __init__(
         self,
         returnn_config: ReturnnConfig,

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -1,4 +1,4 @@
-__all__ = ["CompileTFGraphJob", "CompileNativeOpJob"]
+__all__ = ["CompileTFGraphJob", "CompileNativeOpJob", "OnnxExportJob"]
 
 from sisyphus import *
 
@@ -209,9 +209,9 @@ class CompileNativeOpJob(Job):
 
 class OnnxExportJob(Job):
     """
-        Export an ONNX model using the appropriate RETURNN tool script.
+    Export an ONNX model using the appropriate RETURNN tool script.
 
-        Currently only supports PyTorch via tools/torch_export_to_onnx.py
+    Currently only supports PyTorch via tools/torch_export_to_onnx.py
     """
 
     def __init__(

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -1,4 +1,4 @@
-__all__ = ["CompileTFGraphJob", "CompileNativeOpJob", "OnnxExportJob"]
+__all__ = ["CompileTFGraphJob", "CompileNativeOpJob", "TorchOnnxExportJob"]
 
 from sisyphus import *
 
@@ -207,7 +207,7 @@ class CompileNativeOpJob(Job):
             shutil.move(files[1], self.out_grad_op.get_path())
 
 
-class OnnxExportJob(Job):
+class TorchOnnxExportJob(Job):
     """
     Export an ONNX model using the appropriate RETURNN tool script.
 
@@ -218,7 +218,7 @@ class OnnxExportJob(Job):
         self,
         *,
         returnn_config: ReturnnConfig,
-        checkpoint: Union[Checkpoint, PtCheckpoint],
+        checkpoint: PtCheckpoint,
         device: str = "cpu",
         returnn_python_exe: Optional[tk.Path] = None,
         returnn_root: Optional[tk.Path] = None,
@@ -234,8 +234,6 @@ class OnnxExportJob(Job):
 
         self.returnn_config = returnn_config
         self.checkpoint = checkpoint
-        if isinstance(checkpoint, Checkpoint):
-            raise ValueError("Tensorflow checkpoint export is currently not supported")
         self.device = device
         self.returnn_python_exe = util.get_returnn_python_exe(returnn_python_exe)
         self.returnn_root = util.get_returnn_root(returnn_root)

--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -9,12 +9,12 @@ import logging
 import os
 import shutil
 import subprocess as sp
-from typing import Optional, Union
+from typing import Optional
 
 import i6_core.util as util
 
 from .config import ReturnnConfig
-from .training import Checkpoint, PtCheckpoint
+from .training import PtCheckpoint
 
 
 class CompileTFGraphJob(Job):


### PR DESCRIPTION
A wrapper around the Returnn-Tool. Be aware that I never tested a "normal" pipeline with this, I just used some dummy `torch_export_to_onnx.py` script to verify this jobs works.