### PR TITLE
Add support for encoding and sparse data in RasrAlignmentDumpHDFJob

### DIFF
--- a/lib/rasr_cache.py
+++ b/lib/rasr_cache.py
@@ -13,7 +13,6 @@ import logging
 import mmap
 import numpy
 import os
-import sys
 import typing
 import zlib
 from struct import pack, unpack
@@ -51,7 +50,8 @@ class FileArchive:
     start_recovery_tag = 0xAA55AA55
     end_recovery_tag = 0x55AA55AA
 
-    def __init__(self, filename, must_exists=False):
+    def __init__(self, filename, must_exists=False, encoding="ascii"):
+        self.encoding = encoding
 
         self.ft = {}  # type: typing.Dict[str,FileInfo]
         if os.path.exists(filename):
@@ -182,12 +182,12 @@ class FileArchive:
         return res
 
     # write routines
-    def write_str(self, s):
+    def write_str(self, s, enc="ascii"):
         """
         :param str s:
         :rtype: int
         """
-        return self.f.write(pack("%ds" % len(s), s.encode("ascii")))
+        return self.f.write(pack("%ds" % len(s.encode(enc)), s.encode(enc)))
 
     def write_char(self, i):
         """
@@ -256,7 +256,7 @@ class FileArchive:
             return
         for i in range(count):
             str_len = self.read_u32()
-            name = self.read_str(str_len)
+            name = self.read_str(str_len, self.encoding)
             pos = self.read_u64()
             size = self.read_u32()
             comp = self.read_u32()
@@ -271,8 +271,8 @@ class FileArchive:
         self.write_u32(len(self.ft))
 
         for fi in self.ft.values():
-            self.write_u32(len(fi.name))
-            self.write_str(fi.name)
+            self.write_u32(len(fi.name.encode(self.encoding)))
+            self.write_str(fi.name, self.encoding)
             self.write_u64(fi.pos)
             self.write_u32(fi.size)
             self.write_u32(fi.compressed)
@@ -293,7 +293,7 @@ class FileArchive:
                 continue
 
             fn_len = self.read_u32()
-            name = self.read_str(fn_len)
+            name = self.read_str(fn_len, self.encoding)
             pos = self.f.tell()
             size = self.read_u32()
             comp = self.read_u32()
@@ -322,7 +322,7 @@ class FileArchive:
         """
 
         if typ == "str":
-            return self.read_str(size)
+            return self.read_str(size, self.encoding)
 
         elif typ == "feat":
             type_len = self.read_U32()
@@ -496,8 +496,8 @@ class FileArchive:
         :param times:
         """
         self.write_U32(self.start_recovery_tag)
-        self.write_u32(len(filename))
-        self.write_str(filename)
+        self.write_u32(len(filename.encode(self.encoding)))
+        self.write_str(filename, self.encoding)
         pos = self.f.tell()
         if len(features) > 0:
             dim = len(features[0])
@@ -542,8 +542,8 @@ class FileArchive:
         ) % (dim, duration)
         self.write_U32(self.start_recovery_tag)
         filename = "%s.attribs" % filename
-        self.write_u32(len(filename))
-        self.write_str(filename)
+        self.write_u32(len(filename.encode(self.encoding)))
+        self.write_str(filename, self.encoding)
         pos = self.f.tell()
         size = len(data)
         self.write_u32(size)
@@ -559,9 +559,10 @@ class FileArchiveBundle:
     File archive bundle.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename, encoding="ascii"):
         """
         :param str filename: .bundle file
+        :param str encoding: encoding used in the files
         """
         # filename -> FileArchive
         self.archives = {}  # type: typing.Dict[str,FileArchive]
@@ -569,7 +570,7 @@ class FileArchiveBundle:
         self.files = {}  # type: typing.Dict[str,FileArchive]
         self._short_seg_names = {}
         for line in open(filename).read().splitlines():
-            self.archives[line] = a = FileArchive(line, must_exists=True)
+            self.archives[line] = a = FileArchive(line, must_exists=True, encoding=encoding)
             for f in a.ft.keys():
                 self.files[f] = a
             # noinspection PyProtectedMember
@@ -616,17 +617,18 @@ class FileArchiveBundle:
             a.setAllophones(filename)
 
 
-def open_file_archive(archive_filename, must_exists=True):
+def open_file_archive(archive_filename, must_exists=True, encoding="ascii"):
     """
     :param str archive_filename:
     :param bool must_exists:
+    :param str encoding:
     :rtype: FileArchiveBundle|FileArchive
     """
     if archive_filename.endswith(".bundle"):
         assert must_exists
-        return FileArchiveBundle(archive_filename)
+        return FileArchiveBundle(archive_filename, encoding=encoding)
     else:
-        return FileArchive(archive_filename, must_exists=must_exists)
+        return FileArchive(archive_filename, must_exists=must_exists, encoding=encoding)
 
 
 def is_rasr_cache_file(filename):

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -291,7 +291,7 @@ class RasrAlignmentDumpHDFJob(Job):
     This Job reads Rasr alignment caches and dump them in hdf files.
     """
 
-    __sis_hash_exclude__ = {"encoding": "ascii", "sparse": False, "filter_list_keep": None}
+    __sis_hash_exclude__ = {"encoding": "ascii", "sparse": False, "filter_list_keep": None, "num_classes": None}
 
     def __init__(
         self,
@@ -303,6 +303,7 @@ class RasrAlignmentDumpHDFJob(Job):
         encoding: str = "ascii",
         filter_list_keep: Optional[tk.Path] = None,
         sparse: bool = False,
+        num_classes: Optional[int] = None,
     ):
         """
         :param alignment_caches: e.g. output of an AlignmentJob
@@ -313,6 +314,7 @@ class RasrAlignmentDumpHDFJob(Job):
         :param encoding: encoding of the segment names in the cache
         :param sparse: writes the data to hdf in sparse format
         :param filter_list_keep: list of segment names to dump
+        :param num_classes: number of output labels in the alignment. Can be None if sparse is not set.
         """
         self.alignment_caches = alignment_caches
         self.allophone_file = allophone_file
@@ -322,6 +324,7 @@ class RasrAlignmentDumpHDFJob(Job):
         self.encoding = encoding
         self.filter_list_keep = filter_list_keep
         self.sparse = sparse
+        self.num_classes = num_classes
 
         self.out_hdf_files = [self.output_path(f"data.hdf.{d}") for d in range(len(alignment_caches))]
         self.out_excluded_segments = self.output_path(f"excluded.segments")
@@ -357,7 +360,11 @@ class RasrAlignmentDumpHDFJob(Job):
 
         returnn_root = None if self.returnn_root is None else self.returnn_root.get_path()
         SimpleHDFWriter = get_returnn_simple_hdf_writer(returnn_root)
-        out_hdf = SimpleHDFWriter(filename=self.out_hdf_files[task_id - 1], dim=None if self.sparse else 1)
+        out_hdf = SimpleHDFWriter(
+            filename=self.out_hdf_files[task_id - 1],
+            dim=self.num_classes if self.sparse else 1,
+            ndim=1 if self.sparse else 2,
+        )
 
         excluded_segments = []
 

--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -291,7 +291,7 @@ class RasrAlignmentDumpHDFJob(Job):
     This Job reads Rasr alignment caches and dump them in hdf files.
     """
 
-    __sis_hash_exclude__ = {"encoding": "ascii", "sparse": False, "filter_list_keep": None, "num_classes": None}
+    __sis_hash_exclude__ = {"encoding": "ascii", "filter_list_keep": None, "sparse": False, "num_classes": None}
 
     def __init__(
         self,
@@ -312,8 +312,8 @@ class RasrAlignmentDumpHDFJob(Job):
         :param data_type: type that is used to store the data
         :param returnn_root: file path to the RETURNN repository root folder
         :param encoding: encoding of the segment names in the cache
-        :param sparse: writes the data to hdf in sparse format
         :param filter_list_keep: list of segment names to dump
+        :param sparse: writes the data to hdf in sparse format
         :param num_classes: number of output labels in the alignment. Can be None if sparse is not set.
         """
         self.alignment_caches = alignment_caches


### PR DESCRIPTION
Three independent changes:
* Support for sparse data: the Job currently writes out alignments in (B, T, 1) but some datasets expect (B, T). This PR adds the option `sparse` that stores the data in sparse format if enabled.
* Support encoding: In case the segment names contain non-ascii characters, we want to specify a different encoding (e.g. "utf-8"). This is already supported in RASR, but the `lib.rasr_cache.FileArchive` needed a bit of enabling.
* added a `filter_list_keep` so that we can directly remove unwanted segments from the hdf.