### PR TITLE
FlowNetwork post_config hashing

### DIFF
--- a/rasr/flow.py
+++ b/rasr/flow.py
@@ -372,7 +372,7 @@ class FlowNetwork:
             "params": self.params,
             "hidden_inputs": self.hidden_inputs,
             "config": self.config,
-            "post_config": self.post_config,
+            "post_config": None,
         }
         return state
 


### PR DESCRIPTION
As mentioned in #436, the `post_config` is added to the state which should not be the case.

As suggested by @JackTemaki, I set it to `None` here and we can see if this breaks any hashes in the AppTek pipeline test.