### PR TITLE
remove unknown token from known vocab

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -241,6 +241,12 @@ class FilterCorpusRemoveUnknownWordSegmentsJob(Job):
         with open_func(lex_path, "rt") as f:
             lex_root = ET.parse(f)
         vocabulary = set([maybe_to_lower(o.text.strip() if o.text else "") for o in lex_root.findall(".//orth")])
+        vocabulary -= {
+            maybe_to_lower(o.text.strip() if o.text else "")
+            for l in lex_root.findall(".//lemma")
+            if l.attrib.get("special") == "unknown"
+            for o in l.findall(".//orth")
+        }
 
         c = corpus.Corpus()
         c.load(self.corpus.get_path())


### PR DESCRIPTION
If the lexicon contains an UNKNOWN token (== lemma with "special"="unknown") then its orth is still added to the known vocabulary. Thus, if a sentence literally has transcribed an unknown word, this is treated as "known" for the purpose of filtering.

Here I propose to remove _all_ orth that appear in the special unknown lemma from the vocabulary.