### PR TITLE
Fix number of CPUs for AdvancedTreeSearch

### DIFF
--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -239,7 +239,7 @@ class AdvancedTreeSearchJob(rasr.RasrCommand, Job):
         self.feature_flow.write_to_file("feature.flow")
         util.write_paths_to_file(self.out_lattice_bundle, self.out_single_lattice_caches.values())
         extra_code = "export OMP_NUM_THREADS={0}\nexport TF_DEVICE='{1}'".format(
-            math.ceil(self.cpu / 2), "gpu" if self.use_gpu else "cpu"
+            math.ceil(self.cpu), "gpu" if self.use_gpu else "cpu"
         )
         self.write_run_script(self.exe, "recognition.config", extra_code=extra_code)
 


### PR DESCRIPTION
I am measuring RTFs, for this I need precise specification of the number of cores a job is supposed to run on.

Specifying `cpu=2` in the constructor of `AdvancedTreeSearchJob` in practice meant the jobs only consumes 100% (un-normalized, so only one core) of CPU, because `OMP_NUM_THREADS` is set to `cpu / 2`, i.e. `1`.

Removing the division by two leads the job to consume the desired 200%, i.e. 2 cores. This division by two is very strange to me and I'm struggling to think of the original motivation here. I'm not even sure it's a bug -- other than what I could observe from my use case, where the behavior indeed seemed buggy, there might be something I'm missing.

@JackTemaki You wrote that piece of code in the first place, so you're likely the most qualified to answer here. :) I'd love to know the original motivation behind the `/ 2`.