### PR TITLE
Onnx Feature Scorer

### DIFF
--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -16,7 +16,7 @@ Path = setup_path(__package__)
 
 import os
 
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 
 from .config import *
 from i6_core.util import get_returnn_root
@@ -138,7 +138,7 @@ class OnnxFeatureScorer(FeatureScorer):
         io_map: Dict[str, str],
         label_log_posterior_scale: float = 1.0,
         label_prior_scale: float = 0.7,
-        label_log_prior_file: tk.Path = None,
+        label_log_prior_file: Optional[tk.Path] = None,
         apply_log_on_output: bool = False,
         negate_output: bool = True,
         intra_op_threads: int = 1,

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -130,10 +130,10 @@ class PrecomputedHybridFeatureScorer(FeatureScorer):
 class OnnxFeatureScorer(FeatureScorer):
     def __init__(
         self,
+        *,
         mixtures,
         model,
         io_map,
-        *args,
         label_log_posterior_scale=1.0,
         label_prior_scale=0.7,
         label_log_prior_file=None,

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -127,7 +127,7 @@ class PrecomputedHybridFeatureScorer(FeatureScorer):
         self.config.normalize_mixture_weights = False
 
 
-class OnnxFeatureScorer(rasr.FeatureScorer):
+class OnnxFeatureScorer(FeatureScorer):
     def __init__(
         self,
         mixtures,

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -133,14 +133,14 @@ class OnnxFeatureScorer(FeatureScorer):
     def __init__(
         self,
         *,
-        mixtures: Union[str, tk.Path],
-        model: Union[str, tk.Path],
+        mixtures: tk.Path,
+        model: tk.Path,
         io_map: Dict[str, str],
         label_log_posterior_scale: float = 1.0,
         label_prior_scale: float = 0.7,
-        label_log_prior_file: Union[str, tk.Path] = None,
-        apply_log_on_output: Bool = False,
-        negate_output: Bool = True,
+        label_log_prior_file: tk.Path = None,
+        apply_log_on_output: bool = False,
+        negate_output: bool = True,
         intra_op_threads: int = 1,
         inter_op_threads: int = 1,
         **kwargs,
@@ -170,7 +170,7 @@ class OnnxFeatureScorer(FeatureScorer):
 
         self.config.session.file = model
 
-        if label_log_prior_file:
+        if apply_log_on_output:
             self.config.apply_log_on_output = apply_log_on_output
         if not negate_output:
             self.config.negate_output = negate_output

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -16,7 +16,7 @@ Path = setup_path(__package__)
 
 import os
 
-from typing import Union, Dict, Bool
+from typing import Union, Dict
 
 from .config import *
 from i6_core.util import get_returnn_root

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -151,13 +151,13 @@ class OnnxFeatureScorer(FeatureScorer):
         :param io_map: mapping between internal rasr identifiers and the model related input/output. Default key values
                             are "features" and "output", and optionally "features-size", e.g.
                             io_map = {"features": "data", "output": "classes"}
-        :param float label_log_posterior_scale: scales for the log probability of a label e.g. 1.0 is recommended
-        :param float label_prior_scale: scale for the prior log probability of a label reasonable e.g. values in [0.1, 0.7] interval
-        :param str|tk.Path label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method
-        :param bool apply_log_on_output: whether to apply the log-function on the output, usefull if the model outputs softmax instead of log-softmax
-        :param bool negate_output: whether negate output (because the model outputs log softmax and not negative log softmax
-        :param int intra_op_threads: Onnxruntime session's number of parallel threads within each operator
-        :param int inter_op_threads: Onnxruntime session's number of parallel threads between operators used only for parallel execution mode
+        :param label_log_posterior_scale: scales for the log probability of a label e.g. 1.0 is recommended
+        :param label_prior_scale: scale for the prior log probability of a label reasonable e.g. values in [0.1, 0.7] interval
+        :param label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method
+        :param apply_log_on_output: whether to apply the log-function on the output, usefull if the model outputs softmax instead of log-softmax
+        :param negate_output: whether negate output (because the model outputs log softmax and not negative log softmax
+        :param intra_op_threads: Onnxruntime session's number of parallel threads within each operator
+        :param inter_op_threads: Onnxruntime session's number of parallel threads between operators used only for parallel execution mode
         """
         super().__init__(*args, **kwargs)
 

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -137,7 +137,7 @@ class OnnxFeatureScorer(FeatureScorer):
         model: tk.Path,
         io_map: Dict[str, str],
         label_log_posterior_scale: float = 1.0,
-        label_prior_scale: float = 0.7,
+        label_prior_scale: float,
         label_log_prior_file: Optional[tk.Path] = None,
         apply_log_on_output: bool = False,
         negate_output: bool = True,
@@ -169,11 +169,8 @@ class OnnxFeatureScorer(FeatureScorer):
             self.config.prior_file = label_log_prior_file
 
         self.config.session.file = model
-
-        if apply_log_on_output:
-            self.config.apply_log_on_output = apply_log_on_output
-        if not negate_output:
-            self.config.negate_output = negate_output
+        self.config.apply_log_on_output = apply_log_on_output
+        self.config.negate_output = negate_output
 
         self.post_config.session.intra_op_num_threads = intra_op_threads
         self.post_config.session.inter_op_num_threads = inter_op_threads

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -144,15 +144,16 @@ class OnnxFeatureScorer(FeatureScorer):
         **kwargs,
     ):
         """
-        :param str mixtures: path to a *.mix file e.g. output of either EstimateMixturesJob or CreateDummyMixturesJob
-        :param str model: path of a model e.g. output of ExportPyTorchModelToOnnxJob
+        :param str|tk.Path mixtures: path to a *.mix file e.g. output of either EstimateMixturesJob or CreateDummyMixturesJob
+        :param str|tk.Path model: path of a model e.g. output of ExportPyTorchModelToOnnxJob
         :param dict io_map: mapping between internal rasr identifiers and the model related input/output. Default key values
-                            are "features" and "output", and optionally "features-size"
+                            are "features" and "output", and optionally "features-size", e.g.
+                            io_map = {"features": "data", "output": "classes"}
         :param float label_log_posterior_scale: scales for the log probability of a label e.g. 1.0 is recommended
         :param float label_prior_scale: scale for the prior log probability of a label reasonable e.g. values in [0.1, 0.7] interval
-        :param str label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method
+        :param str|tk.Path label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method
         :param bool apply_log_on_output: whether to apply the log-function on the output, usefull if the model outputs softmax instead of log-softmax
-        :param bool negate_output: wheter negate output (because the model outputs log softmax and not negative log softmax
+        :param bool negate_output: whether negate output (because the model outputs log softmax and not negative log softmax
         :param int intra_op_threads: Onnxruntime session's number of parallel threads within each operator
         :param int inter_op_threads: Onnxruntime session's number of parallel threads between operators used only for parallel execution mode
         """

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -153,6 +153,8 @@ class OnnxFeatureScorer(FeatureScorer):
         :param str label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method
         :param bool apply_log_on_output: whether to apply the log-function on the output, usefull if the model outputs softmax instead of log-softmax
         :param bool negate_output: wheter negate output (because the model outputs log softmax and not negative log softmax
+        :param int intra_op_threads: Onnxruntime session's number of parallel threads within each operator
+        :param int inter_op_threads: Onnxruntime session's number of parallel threads between operators used only for parallel execution mode
         """
         super().__init__(*args, **kwargs)
 

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -16,6 +16,8 @@ Path = setup_path(__package__)
 
 import os
 
+from typing import Union, Dict, Bool
+
 from .config import *
 from i6_core.util import get_returnn_root
 
@@ -131,22 +133,22 @@ class OnnxFeatureScorer(FeatureScorer):
     def __init__(
         self,
         *,
-        mixtures,
-        model,
-        io_map,
-        label_log_posterior_scale=1.0,
-        label_prior_scale=0.7,
-        label_log_prior_file=None,
-        apply_log_on_output=False,
-        negate_output=True,
-        intra_op_threads=1,
-        inter_op_threads=1,
+        mixtures: Union[str, tk.Path],
+        model: Union[str, tk.Path],
+        io_map: Dict[str, str],
+        label_log_posterior_scale: float = 1.0,
+        label_prior_scale: float = 0.7,
+        label_log_prior_file: Union[str, tk.Path] = None,
+        apply_log_on_output: Bool = False,
+        negate_output: Bool = True,
+        intra_op_threads: int = 1,
+        inter_op_threads: int = 1,
         **kwargs,
     ):
         """
-        :param str|tk.Path mixtures: path to a *.mix file e.g. output of either EstimateMixturesJob or CreateDummyMixturesJob
-        :param str|tk.Path model: path of a model e.g. output of ExportPyTorchModelToOnnxJob
-        :param dict io_map: mapping between internal rasr identifiers and the model related input/output. Default key values
+        :param mixtures: path to a *.mix file e.g. output of either EstimateMixturesJob or CreateDummyMixturesJob
+        :param model: path of a model e.g. output of ExportPyTorchModelToOnnxJob
+        :param io_map: mapping between internal rasr identifiers and the model related input/output. Default key values
                             are "features" and "output", and optionally "features-size", e.g.
                             io_map = {"features": "data", "output": "classes"}
         :param float label_log_posterior_scale: scales for the log probability of a label e.g. 1.0 is recommended

--- a/rasr/feature_scorer.py
+++ b/rasr/feature_scorer.py
@@ -146,7 +146,8 @@ class OnnxFeatureScorer(FeatureScorer):
         """
         :param str mixtures: path to a *.mix file e.g. output of either EstimateMixturesJob or CreateDummyMixturesJob
         :param str model: path of a model e.g. output of ExportPyTorchModelToOnnxJob
-        :param dict io_map: mapping between internal rasr identifiers and the model related input/output
+        :param dict io_map: mapping between internal rasr identifiers and the model related input/output. Default key values
+                            are "features" and "output", and optionally "features-size"
         :param float label_log_posterior_scale: scales for the log probability of a label e.g. 1.0 is recommended
         :param float label_prior_scale: scale for the prior log probability of a label reasonable e.g. values in [0.1, 0.7] interval
         :param str label_log_prior_file: xml file containing log prior probabilities e.g. estimated from the model via povey method


### PR DESCRIPTION
Starting with the `apptek` version, I renamed some variables in order to decouple this from the old GMM feature scorer. Moreover, 2 internal rasr variables with their default values are added.

The outdated wrong FH label scorer should be deleted.