### PR TITLE
Fix the MergeAudioDirsJob for fairseq training

### DIFF
--- a/fairseq/manifest.py
+++ b/fairseq/manifest.py
@@ -43,7 +43,19 @@ class MergeAudioDirsJob(Job):
                     continue
                 base_name = os.path.basename(file)
                 dst = os.path.join(self.out_audio_dir_path, base_name)
-                os.symlink(file, dst)
+                if not os.path.exists(dst) and os.path.realpath(dst) != file:
+                    os.symlink(file, dst)
+                elif os.path.exists(dst) and os.path.realpath(dst) != file:
+                    i = 2
+                    new_dst = f"{os.path.splitext(dst)[0]}_{i}.{self.file_extension}"
+                    while os.path.exists(new_dst):
+                        if os.path.realpath(new_dst) == file:
+                            break
+                        else:
+                            i += 1
+                        new_dst = f"{os.path.splitext(dst)[0]}_{i}.{self.file_extension}"
+                    if os.path.realpath(new_dst) != file:
+                        os.symlink(file, new_dst)
 
 
 class CreateManifestJob(Job):

--- a/fairseq/manifest.py
+++ b/fairseq/manifest.py
@@ -57,7 +57,7 @@ class MergeAudioDirsJob(Job):
                     else:
                         i += 1
                     new_dst = f"{os.path.splitext(dst)[0]}_{i}.{self.file_extension}"
-                if os.path.realpath(new_dst) != file:
+                if not os.path.exists(dst) and os.path.realpath(new_dst) != file:
                     os.symlink(file, new_dst)
 
 

--- a/fairseq/manifest.py
+++ b/fairseq/manifest.py
@@ -52,6 +52,7 @@ class MergeAudioDirsJob(Job):
             while not creation_complete:
                 while os.path.exists(dst):
                     if os.path.realpath(dst) == file:
+                        creation_complete = True
                         break
                     dst = f"{os.path.splitext(dst)[0]}_{i}.{self.file_extension}"
                     i += 1

--- a/fairseq/manifest.py
+++ b/fairseq/manifest.py
@@ -57,7 +57,7 @@ class MergeAudioDirsJob(Job):
                     else:
                         i += 1
                     new_dst = f"{os.path.splitext(dst)[0]}_{i}.{self.file_extension}"
-                if not os.path.exists(dst) and os.path.realpath(new_dst) != file:
+                else:
                     os.symlink(file, new_dst)
 
 


### PR DESCRIPTION
With the current version, if file name from two directories are the same, there will be `file already exists error` when doing the symlink `os.symlink(file, dst)` since the dst are the same
```
a.wav -> dir_path_1/a.wav
a.wav -> dir_path_2/a.wav
```
This PR fixes this issue by renaming dst for the second file
```
a.wav -> dir_path_1/a.wav
a_2.wav -> dir_path_2/a.wav
```