### PR TITLE
Add error_threshold param to ffmpeg conversion jobs

### DIFF
--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -32,6 +32,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         recover_duration: Optional[bool] = None,
         input_codec: Optional[str] = None,
         input_codec_options: Optional[List[str]] = None,
+        error_threshold: int = 0,
     ):
         """
         For all parameter holds that "None" means to use the ffmpeg defaults, which depend on the input file
@@ -55,8 +56,9 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
             There might be minimal differences when converting the encoding, so only set this to `False` if you're
             willing to accept this risk. `None` (default) means that the duration is recovered if either `output_format`
             or `codec` is specified because this might possibly lead to duration mismatches.
-        :param in_codec: specify the codec of the input file
-        :param in_codec_options: specify additional codec specific options for the in_codec
+        :param input_codec: specify the codec of the input file
+        :param input_codec_options: specify additional codec specific options for the in_codec
+        :param error_threshold: Allow upto this many files to fail conversion before failing this job
         """
         ffmpeg_input_options = []
         ffmpeg_options = []
@@ -104,4 +106,5 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
             output_format=output_format,
             ffmpeg_binary=ffmpeg_binary,
             hash_binary=hash_binary,
+            error_threshold=error_threshold,
         )

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -108,6 +108,7 @@ class BlissFfmpegJob(Job):
 
         self.out_audio_folder = self.output_path("audio/", directory=True)
         self.out_corpus = self.output_path("corpus.xml.gz")
+        self.out_failed_files = None
         if self.error_threshold > 0:
             self.out_failed_files = self.output_path("failed_files.txt")
 
@@ -139,7 +140,7 @@ class BlissFfmpegJob(Job):
         else:
             c.dump(tk.uncached_path(self.out_corpus))
 
-        if hasattr(self, "out_failed_files"):
+        if self.out_failed_files is not None:
             with open(self.out_failed_files.get_path(), "wt") as out:
                 out.write("\n".join(self.failed_files))
 


### PR DESCRIPTION
I have a use-case where some files have invalid data, but correct headers. I cannot change that and the only way to detect if they are broken is trying to play them or trying to convert them. Since I can't do anything about them being broken I'm ok with not converting them. To that end I have added an optional error_threshold parameter to the conversion job to allow a certain number of errors before failing. By default that threshold is 0 (current behavior).