### PR TITLE
ReturnnTrainingJob, `python -mtorch.distributed.run` instead of `torchrun`

### DIFF
--- a/returnn/training.py
+++ b/returnn/training.py
@@ -250,7 +250,9 @@ class ReturnnTrainingJob(Job):
         if self.horovod_num_processes:
             if self.distributed_launch_cmd == "torchrun":
                 # use torchrun to lauch DDP training when the backend is torch
-                prefix = ["torchrun"]
+                # Instead of using the torchrun binary, directly execute the corresponding Python module
+                # and directly use the correct Python environment.
+                prefix = [self.returnn_python_exe.get_path(), "-mtorch.distributed.run"]
                 if (self.multi_node_slots or 1) == 1:
                     prefix += ["--standalone"]
                 prefix += [


### PR DESCRIPTION
This directly uses the correct Python environment. Otherwise you would need to make sure that PATH covers the right environment, and that can easily result in mixups of the env.