### PR TITLE
Instanciate delayed variables when printing a staged network dict

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -217,7 +217,7 @@ class ReturnnConfig:
             pp = pprint.PrettyPrinter(indent=2, width=150, **self.pprint_kwargs)
             network_definition = self.staged_network_dict[epoch]
             if isinstance(network_definition, dict):
-                content = "\nnetwork = %s" % pp.pformat(network_definition)
+                content = "\nnetwork = %s" % pp.pformat(instanciate_delayed(network_definition))
             elif isinstance(network_definition, str):
                 content = network_definition
             else:


### PR DESCRIPTION
Otherwise delayed variables and paths are stringified wrongly (via their repr, which for paths leads to `<tk.Path path="...">`).