### PR TITLE
BlissToOggZipJob: fix rsync for many files

### DIFF
--- a/returnn/oggzip.py
+++ b/returnn/oggzip.py
@@ -163,7 +163,7 @@ class BlissToOggZipJob(Job):
                 "-av",
                 os.path.join(
                     tmp_dir,
-                    os.path.basename(self.zip_subarchives.path_template).replace(".$(TASK).zip", ".*/*"),
+                    os.path.basename(self.zip_subarchives.path_template).replace(".$(TASK).zip", ".*/"),
                 ),
                 output_folder,
             ]


### PR DESCRIPTION
When merging the different zip files in the `BlissToOggZipJob`'s `merge` task, the job executes `$ rsync -av /var/tmp/sis_x8jg4syk/ogg.*/* /var/tmp/sis_x8jg4syk/out.ogg` which in my case crashed with `/bin/sh: 1: rsync: Argument list too long`. Removing the second `*` solved the issue for me.