### PR TITLE
ComputeBestMixJob, InterpolateNgramLmJob, fix check_call

### DIFF
--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -441,7 +441,7 @@ class InterpolateNgramLmJob(Job):
             if i == 0:
                 c = ["-lambda", str(lmbd.get())]
             elif i == 1:
-                c = [""]
+                c = []
             else:
                 c = [f"-mix-lambda{i}", str(lmbd.get())]
             cmd += c

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -426,24 +426,24 @@ class InterpolateNgramLmJob(Job):
     def _create_cmd(self) -> List[str]:
         """creates bash script that will be executed in the run Task"""
         cmd = [self.ngram_exe.get_path()]
-        cmd += ["-order", f"{self.ngram_order} -unk"]
+        cmd += ["-order", str(self.ngram_order), "-unk"]
 
         for i, lm in enumerate(self.ngram_lms):
             if i == 0:
-                c = ["-lm", f"{lm.get_path()}"]
+                c = ["-lm", lm.get_path()]
             elif i == 1:
-                c = ["-mix-lm", f"{lm.get_path()}"]
+                c = ["-mix-lm", lm.get_path()]
             else:
-                c = [f"-mix-lm{i}", f"{lm.get_path()}"]
+                c = [f"-mix-lm{i}", lm.get_path()]
             cmd += c
 
         for i, lmbd in enumerate(self.weights):
             if i == 0:
-                c = ["-lambda", f"{lmbd.get()}"]
+                c = ["-lambda", str(lmbd.get())]
             elif i == 1:
-                c = [f""]
+                c = [""]
             else:
-                c = [f"-mix-lambda{i}", f"{lmbd.get()}"]
+                c = [f"-mix-lambda{i}", str(lmbd.get())]
             cmd += c
         cmd += ["-write-lm", "interpolated.lm.gz"]
 

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -353,7 +353,7 @@ class ComputeBestMixJob(Job):
     def run(self):
         """Call the srilm script and extracts the different weights from the log, then relinks log to output folder"""
         cmd = self._create_cmd()
-        subprocess.check_call(cmd, stdout=open("cbm.log", "wb"), stderr=subprocess.STDOUT)
+        subprocess.check_call(cmd, stdout=open("cbm.log", "wt"), stderr=subprocess.STDOUT)
 
         lines = open("cbm.log", "rt").readlines()
         lbds = lines[-2].split("(")[1].replace(")", "")

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -424,7 +424,7 @@ class InterpolateNgramLmJob(Job):
         yield Task("run", rqmt=self.rqmt)
 
     def _create_cmd(self) -> List[str]:
-        """creates bash script that will be executed in the run Task"""
+        """:return: the command"""
         cmd = [self.ngram_exe.get_path()]
         cmd += ["-order", str(self.ngram_order), "-unk"]
 

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -353,7 +353,7 @@ class ComputeBestMixJob(Job):
     def run(self):
         """Call the srilm script and extracts the different weights from the log, then relinks log to output folder"""
         cmd = self._create_cmd()
-        subprocess.check_call(cmd, stdout=open("cbm.log", "wt"), stderr=subprocess.STDOUT)
+        subprocess.check_call(cmd, stdout=open("cbm.log", "wb"), stderr=subprocess.STDOUT)
 
         lines = open("cbm.log", "rt").readlines()
         lbds = lines[-2].split("(")[1].replace(")", "")

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -450,7 +450,7 @@ class InterpolateNgramLmJob(Job):
         return cmd
 
     def run(self):
-        """run the previously created bash script"""
+        """run the command"""
         cmd = self._create_cmd()
         subprocess.check_call(cmd)
         shutil.move("interpolated.lm.gz", self.out_interpolated_lm.get_path())

--- a/lm/srilm.py
+++ b/lm/srilm.py
@@ -341,7 +341,7 @@ class ComputeBestMixJob(Job):
         yield Task("run", mini_task=True)
 
     def _create_cmd(self) -> List[str]:
-        """creates bash script that will be executed in the run Task"""
+        """:return: the command"""
         cmd = [self.compute_best_mix_exe.get_path()]
 
         ppl_log = [x.get_path() for x in self.ppl_logs]


### PR DESCRIPTION
For some reason we left 2 Jobs as command strings instead of creating an executable.
This does not work (would only work with `shell=True`).
Since we did not want this back when #406 was done, I propose to change the two jobs too. 
Successfully tested this just now.