### PR TITLE
Change BlissFfmpegJob threading

### DIFF
--- a/audio/encoding.py
+++ b/audio/encoding.py
@@ -33,6 +33,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         input_codec: Optional[str] = None,
         input_codec_options: Optional[List[str]] = None,
         error_threshold: int = 0,
+        cpu_rqmt: int = 9,
     ):
         """
         For all parameter holds that "None" means to use the ffmpeg defaults, which depend on the input file
@@ -59,6 +60,7 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
         :param input_codec: specify the codec of the input file
         :param input_codec_options: specify additional codec specific options for the in_codec
         :param error_threshold: Allow upto this many files to fail conversion before failing this job
+        :param cpu_rqmt: number of cpu cores to use
         """
         ffmpeg_input_options = []
         ffmpeg_options = []
@@ -107,4 +109,5 @@ class BlissChangeEncodingJob(BlissFfmpegJob):
             ffmpeg_binary=ffmpeg_binary,
             hash_binary=hash_binary,
             error_threshold=error_threshold,
+            cpu_rqmt=cpu_rqmt,
         )

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -82,6 +82,7 @@ class BlissFfmpegJob(Job):
         hash_binary: bool = False,
         ffmpeg_input_options: Optional[List[str]] = None,
         error_threshold: int = 0,
+        cpu_rqmt: int = 9,
     ):
         """
 
@@ -94,6 +95,7 @@ class BlissFfmpegJob(Job):
                             in which case the binary needs to be hashed
         :param ffmpeg_input_options: list of ffmpeg parameters thare are applied for reading the input files
         :param error_threshold: Allow upto this many files to fail conversion before failing this job
+        :param cpu_rqmt: number of cpu cores to use
         """
         self.corpus_file = corpus_file
         self.ffmpeg_input_options = ffmpeg_input_options
@@ -113,7 +115,7 @@ class BlissFfmpegJob(Job):
             self.out_failed_files = self.output_path("failed_files.txt")
 
         # e.g. 1 core for python and 4x2 cores for ffmpeg, one for input processing and one for output processing
-        self.rqmt = {"time": 4, "cpu": 9, "mem": 8}
+        self.rqmt = {"time": 4, "cpu": cpu_rqmt, "mem": 8}
 
     def tasks(self):
         yield Task("run", rqmt=self.rqmt)
@@ -221,4 +223,5 @@ class BlissFfmpegJob(Job):
             d.pop("ffmpeg_binary")
         if kwargs["error_threshold"] == 0:
             d.pop("error_threshold")
+        d.pop("cpu_rqmt")
         return super().hash(d)

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -82,7 +82,7 @@ class BlissFfmpegJob(Job):
         hash_binary: bool = False,
         ffmpeg_input_options: Optional[List[str]] = None,
         error_threshold: int = 0,
-        cpu_rqmt: int = 9,
+        cpu_rqmt: int = 5,
     ):
         """
 

--- a/audio/ffmpeg.py
+++ b/audio/ffmpeg.py
@@ -112,7 +112,8 @@ class BlissFfmpegJob(Job):
         if self.error_threshold > 0:
             self.out_failed_files = self.output_path("failed_files.txt")
 
-        self.rqmt = {"time": 4, "cpu": 4, "mem": 8}
+        # e.g. 1 core for python and 4x2 cores for ffmpeg, one for input processing and one for output processing
+        self.rqmt = {"time": 4, "cpu": 9, "mem": 8}
 
     def tasks(self):
         yield Task("run", rqmt=self.rqmt)
@@ -124,11 +125,11 @@ class BlissFfmpegJob(Job):
 
     def run(self):
         c = corpus.Corpus()
-        c.load(tk.uncached_path(self.corpus_file))
+        c.load(self.corpus_file.get_path())
 
         from multiprocessing import pool
 
-        p = pool.Pool(self.rqmt["cpu"])
+        p = pool.Pool(self.rqmt["cpu"] // 2)
         p.map(self._perform_ffmpeg, c.all_recordings())
 
         for r in c.all_recordings():
@@ -138,7 +139,7 @@ class BlissFfmpegJob(Job):
         if self.recover_duration:
             c.dump("temp_corpus.xml.gz")
         else:
-            c.dump(tk.uncached_path(self.out_corpus))
+            c.dump(self.out_corpus.get_path())
 
         if self.out_failed_files is not None:
             with open(self.out_failed_files.get_path(), "wt") as out:
@@ -195,13 +196,9 @@ class BlissFfmpegJob(Job):
         target = os.path.join(self.out_audio_folder.get_path(), audio_filename)
         if not os.path.exists(target):
             logging.info(f"try converting {target}")
-            command_head = [
-                self.ffmpeg_binary,
-                "-hide_banner",
-                "-y",
-            ]
+            command_head = [self.ffmpeg_binary, "-hide_banner", "-y", "-threads", "1"]
             command_in = ["-i", recording.audio]
-            command_out = [target]
+            command_out = ["-threads", "1", target]
             in_options = self.ffmpeg_input_options or []
             out_options = self.ffmpeg_options or []
             command = command_head + in_options + command_in + out_options + command_out


### PR DESCRIPTION
While working in a different cluster environment I found out that the job was spawing way more threads than it should, leading to conflicts with the cluster settings and also having an impact on efficiency.

These changes force ffmpeg to use only one thread for the input processing and one thread for the output processing. The pool size is adjusted accordingly. 

I also increased the number of default cores, but this is debatable. The extra thread for the python process might not be strictly necessary for maximum performance (I did not test for that), but the cluster environment kills jobs that uses more threads than requested, and with this settings it worked. 

From commit message
 - force ffmpeg to use 1 thread for input and output processing each
 - set higher number of default cpu cores
 - remote some tk.uncached_path calls