### PR TITLE
Tedlium not distinct corpora names for the 3 partitions

### DIFF
--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -219,6 +219,7 @@ class CreateTEDLIUM2BlissCorpusJob(Job):
 class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
     """
     It has the same logic as CreateTEDLIUM2BlissCorpusJob but the corpus name is distinct for each partition
+    and the common text normalization for eliminating space before apostroph, similarly to Kaldi and ESPNet is applied
     """
 
     def make_corpus(self):

--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -261,12 +261,15 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                     last_rec_name = rec_name
                     seg_id = 1
 
+                #This solved the TedLium known problem of additional space before apostrof
+                normalized_text = text.replace(" '", "'")
+
                 segment = corpus.Segment()
                 segment.name = str(seg_id)
                 segment.start = float(start)
                 segment.end = float(end)
                 segment.speaker_name = spk_name
-                segment.orth = text
+                segment.orth = normalized_text
 
                 recording.add_segment(segment)
                 seg_id += 1

--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -318,7 +318,7 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                 segment.start = float(start)
                 segment.end = float(end)
                 segment.speaker_name = spk_name
-                segment.orth = normalized_text
+                segment.orth = text
 
                 recording.add_segment(segment)
                 seg_id += 1

--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -221,9 +221,6 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
     It has the same logic as CreateTEDLIUM2BlissCorpusJob but the corpus name is distinct for each partition
     """
 
-    def __init__(self, corpus_folders):
-        super().__init__(corpus_folders)
-
     def make_corpus(self):
         """
         create bliss corpus from stm file (always include speakers)
@@ -261,7 +258,7 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                     last_rec_name = rec_name
                     seg_id = 1
 
-                #This solved the TedLium known problem of additional space before apostrof
+                # This solved the TedLium known problem of additional space before apostrophe
                 normalized_text = text.replace(" '", "'")
 
                 segment = corpus.Segment()

--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -264,6 +264,7 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                     text = data[idx][6]
                     text = text.replace("imiss", "i miss")
                     text = text.replace("uptheir", "up their")
+                    text = text.replace(" '", "'")
                     data[idx][6] = text
 
                     # train-only: segment boundary non-overlapping extension (kaldi)
@@ -315,14 +316,12 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                     last_rec_name = rec_name
                     seg_id = 1
 
-                normalized_text = text.replace(" '", "'")
-
                 segment = corpus.Segment()
                 segment.name = str(seg_id)
                 segment.start = float(start)
                 segment.end = float(end)
                 segment.speaker_name = spk_name
-                segment.orth = normalized_text
+                segment.orth = text
 
                 recording.add_segment(segment)
                 seg_id += 1

--- a/datasets/tedlium2.py
+++ b/datasets/tedlium2.py
@@ -69,6 +69,8 @@ class CreateTEDLIUM2BlissCorpusJob(Job):
     """
     Processes stm files from TEDLIUM2 corpus folders and creates Bliss corpus files
     Outputs a stm file and a bliss .xml.gz file for each train/dev/test set
+    This job is deprecated due to changes applied to the reference text leading to incomparable results to literature
+    It is recommended to use CreateTEDLIUM2BlissCorpusJobV2
     """
 
     def __init__(self, corpus_folders):
@@ -313,12 +315,14 @@ class CreateTEDLIUM2BlissCorpusJobV2(CreateTEDLIUM2BlissCorpusJob):
                     last_rec_name = rec_name
                     seg_id = 1
 
+                normalized_text = text.replace(" '", "'")
+
                 segment = corpus.Segment()
                 segment.name = str(seg_id)
                 segment.start = float(start)
                 segment.end = float(end)
                 segment.speaker_name = spk_name
-                segment.orth = text
+                segment.orth = normalized_text
 
                 recording.add_segment(segment)
                 seg_id += 1


### PR DESCRIPTION
The corpus name for all train, dev, and test partition is the same. This PR suggests a second version of the job that modifies simply the corpus name.