### PR TITLE
remove cleanup_old_models from disallowed args

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -349,7 +349,6 @@ class ReturnnConfig:
 
         # list of parameters that should never be hashed
         disallowed_in_config = [
-            "cleanup_old_models",
             "log_verbosity",
         ]
         for key in disallowed_in_config:


### PR DESCRIPTION
In many cases it makes sense to have the cleanup settings hashed, as they really result in different trainings when using e.g. checkpoint averaging. 

Editing this after training also breaks the pipeline in most cases, as then following jobs search for non-existing checkpoints.