### PR TITLE
SpellingConversionJob: fix bug: deletion of lemmas

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -392,7 +392,7 @@ class SpellingConversionJob(Job):
                         source_orth, target_orth = target_orth, source_orth
                     mapping[source_orth] = target_orth
         num_mappings = len(mapping)
-        logging.info("A total of {} word mapping paris".format(num_mappings))
+        logging.info("A total of {} word mapping pairs".format(num_mappings))
 
         # compile mapping patterns from extra mapping_rules
         mapping_patterns = []
@@ -448,6 +448,8 @@ class SpellingConversionJob(Job):
 
         # spelling conversion
         for source_orth, target_orth in mapping.items():
+            if source_orth == target_orth:
+                continue
             target_lemma = orth2lemma.get(target_orth, None)
             source_lemma = orth2lemma.get(source_orth, None)
             if target_lemma:


### PR DESCRIPTION
i got some mapping files from the data team where there was e.g

```
> "  "accessorize": "accessorize",
>   "accessorized": "accessorized",

```

so same identical source and target mapping (This happened because the initial mapping file was US -> GB and now got updated to US -> CA)

This now resulted in the deletion of 1000 lemmas in the Job e.g.

```
[2024-04-05 12:45:59,463] INFO: target lemma
<lemma>
  <orth>accessorize</orth>
  <phon>æ k s ɛ s ə ɹ aɪ z</phon>
</lemma>

[2024-04-05 12:45:59,464] INFO: source lemma
<lemma>
  <orth>accessorize</orth>
  <phon>æ k s ɛ s ə ɹ aɪ z</phon>
</lemma>

[2024-04-05 12:45:59,464] INFO: final lemma
<lemma>
  <orth>accessorize</orth>
  <phon>æ k s ɛ s ə ɹ aɪ z</phon>
  <synt>
    <tok>accessorize</tok>
  </synt>
</lemma>
```

I could have cleaned the initial json mapping file, but someone might run into the same issue and does not compare the resulting lexicons => unwanted deletion of lemmas