### PR TITLE
Add functionality to merge subcorpora and recordings for MergeCorporaJob

### DIFF
--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -360,7 +360,7 @@ class MergeCorporaJob(Job):
         to_add_spk = {spk.name: spk for spk in to_add.top_level_speakers()}
         for name, spk in to_add_spk.items():
             if name in base_spk:
-                assert spk == base_spk[name], (
+                assert spk.__dict__ == base_spk[name].__dict__, (
                     f"Found same speaker {name} with different attributes in the base/to be added corpus.\n"
                     f"Speaker attributes (base corpus): {base_spk[name]}.\n"
                     f"Speaker attributes (corpus to be added): {spk}."
@@ -403,7 +403,7 @@ class MergeCorporaJob(Job):
         to_add_spk = {spk.name: spk for spk in to_add.speakers}
         for name, spk in to_add_spk.items():
             if name in base_spk:
-                assert spk == base_spk[name], (
+                assert spk.__dict__ == base_spk[name].__dict__, (
                     f"Found same speaker {name} with different attributes in the base/to be added corpus.\n"
                     f"Speaker attributes (base corpus): {base_spk[name]}.\n"
                     f"Speaker attributes (corpus to be added): {spk}."

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -430,8 +430,6 @@ class MergeCorporaJob(Job):
                     f"Affected segment name: {name}.\n"
                     f"Affected recording (base): {base_seg[name].recording.fullname()}.\n"
                     f"Affected recording (to be added): {seg.recording.fullname()}.\n"
-                    f"Affected corpus (base): {base_seg[name].recording.corpus.fullname()}.\n"
-                    f"Affected corpus (to be added): {seg.recording.corpus.fullname()}.\n"
                 )
             base.add_segment(seg)
 

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -297,7 +297,7 @@ class MergeStrategy(enum.Enum):
     SUBCORPORA = 0  # Merge as subcorpora of a common corpus.
     FLAT = 1  # Flatten corpus structure by ignoring subcorpora.
     CONCATENATE = 2  # Concatenate all subcorpora, recordings and speakers.
-    # Like SUBCORPORA, but flatten each top level subcorpora, and merge subcorpora and recordings with the same name.
+    # Flatten each top level subcorpora, and merge subcorpora and recordings with the same name.
     MERGE_SUBCORPORA_AND_RECORDINGS = 3
 
 

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -366,9 +366,7 @@ class MergeCorporaJob(Job):
                                 rec_name_to_rec[rec.name].add_segment(seg)
             else:
                 assert False, "invalid merge strategy"
-        # import pdb
 
-        # pdb.set_trace()
         merged_corpus.dump(self.out_merged_corpus.get_path())
 
 

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -326,7 +326,7 @@ class MergeCorporaJob(Job):
         merged_corpus.name = self.name
         if self.merge_strategy == MergeStrategy.MERGE_SUBCORPORA_AND_RECORDINGS:
             sc_name_to_sc: Dict[str, corpus.Corpus] = {}
-            rec_name_to_rec: Dict[str, corpus.Recording] = {}
+            rec_name_to_sc_rec: Dict[str, Dict[str, corpus.Recording]] = collections.defaultdict(dict)
         for corpus_path in self.bliss_corpora:
             c = corpus.Corpus()
             c.load(tk.uncached_path(corpus_path))
@@ -356,14 +356,14 @@ class MergeCorporaJob(Job):
                         stored_sc = sc_name_to_sc[sc.name]
                     stored_sc.speakers.update(sc.speakers)
                     for rec in sc.all_recordings():
-                        if rec.name not in rec_name_to_rec:
+                        if rec.name not in rec_name_to_sc_rec[stored_sc.name]:
                             stored_sc.add_recording(rec)
-                            rec_name_to_rec[rec.name] = rec
+                            rec_name_to_sc_rec[stored_sc.name][rec.name] = rec
                         else:
                             # The recording had already been added to some subcorpus.
                             # Gracefully merge the segments from both recordings.
                             for seg in rec.segments:
-                                rec_name_to_rec[rec.name].add_segment(seg)
+                                rec_name_to_sc_rec[stored_sc.name][rec.name].add_segment(seg)
             else:
                 assert False, "invalid merge strategy"
 

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -293,9 +293,9 @@ class CompressCorpusJob(Job):
 
 
 class MergeStrategy(enum.Enum):
-    SUBCORPORA = 0
-    FLAT = 1
-    CONCATENATE = 2
+    SUBCORPORA = 0  # Merge as subcorpora of a common corpus.
+    FLAT = 1  # Flatten corpus structure by ignoring subcorpora.
+    CONCATENATE = 2  # Concatenate all subcorpora, recordings and speakers.
 
 
 class MergeCorporaJob(Job):

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -344,6 +344,9 @@ class MergeCorporaJob(Job):
                 for speaker in c.top_level_speakers():
                     merged_corpus.add_speaker(speaker)
             elif self.merge_strategy == MergeStrategy.MERGE_SUBCORPORA_AND_RECORDINGS:
+                for rec in c.top_level_recordings():
+                    merged_corpus.add_recording(rec)
+                merged_corpus.speakers.update(c.speakers)
                 for sc in c.top_level_subcorpora():
                     if sc.name not in sc_name_to_sc:
                         stored_sc = corpus.Corpus()

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -297,7 +297,7 @@ class MergeStrategy(enum.Enum):
     SUBCORPORA = 0  # Merge as subcorpora of a common corpus.
     FLAT = 1  # Flatten corpus structure by ignoring subcorpora.
     CONCATENATE = 2  # Concatenate all subcorpora, recordings and speakers.
-    MERGE_SUBCORPORA = 3  # Merge subcorpora and recordings with the same name.
+    MERGE_RECURSIVE = 3  # Merge recordings and subcorpora with the same name.
 
 
 class MergeCorporaJob(Job):
@@ -339,7 +339,7 @@ class MergeCorporaJob(Job):
                     merged_corpus.add_recording(rec)
                 for speaker in c.top_level_speakers():
                     merged_corpus.add_speaker(speaker)
-            elif self.merge_strategy == MergeStrategy.MERGE_SUBCORPORA:
+            elif self.merge_strategy == MergeStrategy.MERGE_RECURSIVE:
                 merged_corpus = MergeCorporaJob.merge_corpora(merged_corpus, c)
             else:
                 assert False, "invalid merge strategy"

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from typing import Any
+from typing import Any, Dict
 import pytest
 from sisyphus import setup_path
 from i6_core.corpus.transform import MergeCorporaJob, MergeStrategy
@@ -13,15 +13,15 @@ Path = setup_path(__package__)
 @pytest.mark.skip(reason="Helper class only used in file.")
 class CorpusCreatorHelper:
     @staticmethod
-    def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corpus:
+    def _create_corpus_with_structure(corpus_dict: Dict[str, Any]) -> libcorpus.Corpus:
         """
         Creates a simple corpus from its definition in dictionary form.
         The dictionary can have the following keys and with the respective type:
         - "name": str
-        - "recordings": list[dict[str, Any]]: can have the following keys:
+        - "recordings": list[Dict[str, Any]]: can have the following keys:
             - "name": str
             - "segments": list[str]
-        - "subcorpora": list[dict[str, Any]]: recursive definition of a corpus.
+        - "subcorpora": list[Dict[str, Any]]: recursive definition of a corpus.
 
         :param corpus_dict: Definition of a corpus in dictionary form.
         :return: Corpus object defined by the corpus dictionary provided.
@@ -43,7 +43,7 @@ class CorpusCreatorHelper:
         return corpus
 
     @staticmethod
-    def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: dict[str, Any]) -> bool:
+    def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: Dict[str, Any]) -> bool:
         """
         Asserts that the corpus passed as parameter has the same structure as the simple corpus dictionary provided.
 

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -1,0 +1,254 @@
+import os
+import tempfile
+from typing import Any, Optional
+from sisyphus import setup_path
+
+from i6_core.corpus.transform import MergeCorporaJob, MergeStrategy
+import i6_core.lib.corpus as libcorpus
+
+
+Path = setup_path(__package__)
+
+
+def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corpus:
+    """
+    Creates a simple corpus from its definition in dictionary form.
+    The dictionary can have the following keys and with the respective type:
+    - "name": str
+    - "recordings": list[dict[str, Any]]: can have the following keys:
+        - "name": str
+        - "segments": list[str]
+    - "subcorpora": list[dict[str, Any]]: recursive definition of a corpus.
+
+    :param corpus_dict: Definition of a corpus in dictionary form.
+    :return: Corpus object defined by the corpus dictionary provided.
+    """
+    corpus = libcorpus.Corpus()
+    corpus.name = corpus_dict["name"]
+    for recording_dict in corpus_dict.get("recordings", []):
+        recording = libcorpus.Recording()
+        recording.name = recording_dict["name"]
+        for segment_name in recording_dict.get("segments", []):
+            segment = libcorpus.Segment()
+            segment.name = segment_name
+            segment.orth = ""
+            recording.add_segment(segment)
+        corpus.add_recording(recording)
+    for subcorpus_dict in corpus_dict.get("subcorpora", []):
+        corpus.add_subcorpus(_create_corpus_with_structure(subcorpus_dict))
+
+    return corpus
+
+
+def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: dict[str, Any]) -> bool:
+    """
+    Asserts that the corpus passed as parameter has the same structure as the simple corpus dictionary provided.
+
+    :param corpus: Corpus for which to check the structure.
+    :param corpus_dict: Expected corpus structure.
+    :return: True if the corpus matches the given structure.
+        Doesn't return False whenever the corpus structure doesn't match, but fails with an assertion.
+    """
+    # Check that the corpus name matches.
+    assert (
+        corpus.name == corpus_dict["name"]
+    ), f"Corpus name ({corpus.name}) doesn't coincide with provided ({corpus_dict['name']})."
+
+    # Check that the recordings (and their internal segments) match.
+    recordings_dicts = corpus_dict.get("recordings", [])
+    assert len(corpus.recordings) == len(recordings_dicts), (
+        f"Number of recordings in corpus ({len(corpus.recordings)}) not coinciding "
+        f"with provided ({len(recordings_dicts)})."
+    )
+    for recording_dict in recordings_dicts:
+        segments_from_dict = recording_dict.get("segments", [])
+
+        # Get the recording with the same name.
+        recordings_in_corpus_with_same_name = [
+            r for r in corpus.top_level_recordings() if r.name == recording_dict["name"]
+        ]
+        found_recording = None
+        for r in recordings_in_corpus_with_same_name:
+            if sorted([segment.name for segment in r.segments]) == sorted(segments_from_dict):
+                found_recording = r
+                break
+        assert (
+            found_recording
+        ), f"No recording in {corpus.fullname()} found with the features provided by the user: {recording_dict}. "
+
+    # Recursively check that the subcorpora match.
+    subcorpus_dicts = corpus_dict.get("subcorpora", [])
+    for subcorpus_dict in subcorpus_dicts:
+        matching_subcorpus = [sc for sc in corpus.top_level_subcorpora() if sc.name == subcorpus_dict["name"]]
+        assert (
+            len(matching_subcorpus) == 1
+        ), f"There's more than one subcorpus matching for the subcorpus name {subcorpus_dict['name']}"
+        _check_corpus_with_structure(matching_subcorpus[0], subcorpus_dict)
+
+    return True
+
+
+def test_merge_corpora_job_merge_subcorpus_and_recordings():
+    """
+    Merges two hardcoded corpora with the `MergeStrategy.MERGE_SUBCORPORA` whose structures are the following:
+
+    CORPUS 1            CORPUS 2
+    rec1                rec1
+        seg10               seg13
+    sc1                 sc1
+        rec1                rec1
+            seg1..2             seg3..5
+        rec2
+            seg3..4
+    ------------------------------------
+    sc2                 sc2
+        rec2
+            seg5
+        rec3
+            seg6
+                            sc1
+                                rec1
+                                    seg1
+    ------------------------------------
+                        sc3
+                            rec1
+                                seg1
+                            rec2
+
+    The expected output structure is the following:
+    rec1
+        seg10
+        seg13
+    sc1
+        rec1
+            seg1..5
+        rec2
+            seg3..4
+    ------------------------------------
+    sc2
+        rec2
+            seg5
+        rec3
+            seg6
+        sc1
+            rec1
+                seg1
+    ------------------------------------
+    sc3
+        rec1
+            seg1
+        rec2
+
+    Some notes about the expected output:
+    `MergeStrategy.MERGE_SUBCORPORA` only extends the segment list of the recordings.
+    - The nested subcorpus sc2/sc1 shouldn't be merged with the main subcorpus sc1.
+    Moreover, its recording sc2/sc1/rec1 shouldn't be merged with neither rec1 nor sc1/rec1.
+    `MergeStrategy.MERGE_SUBCORPORA` only takes into consideration the top level subcorpora.
+    - It's intended that sc3/rec2 doesn't have any segments.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # First corpus.
+        c1_path = os.path.join(tmpdir, "c1.xml.gz")
+        c1_structure = {
+            "name": "c1",
+            "recordings": [
+                {"name": "rec1", "segments": ["seg10"]},
+            ],
+            "subcorpora": [
+                {
+                    "name": "sc1",
+                    "recordings": [
+                        {"name": "rec1", "segments": ["seg1", "seg2"]},
+                        {"name": "rec2", "segments": ["seg3", "seg4"]},
+                    ],
+                },
+                {
+                    "name": "sc2",
+                    "recordings": [
+                        {"name": "rec2", "segments": ["seg5"]},
+                        {"name": "rec3", "segments": ["seg6"]},
+                    ],
+                },
+            ],
+        }
+        c1 = _create_corpus_with_structure(c1_structure)
+        c1.dump(c1_path)
+
+        # Second corpus.
+        c2_path = os.path.join(tmpdir, "c2.xml.gz")
+        c2_structure = {
+            "name": "c2",
+            "recordings": [
+                {"name": "rec1", "segments": ["seg13"]},
+            ],
+            "subcorpora": [
+                {"name": "sc1", "recordings": [{"name": "rec1", "segments": ["seg3", "seg4", "seg5"]}]},
+                {
+                    "name": "sc2",
+                    "subcorpora": [
+                        {
+                            "name": "sc1",
+                            "recordings": [{"name": "rec1", "segments": ["seg1"]}],
+                        }
+                    ],
+                },
+                {
+                    "name": "sc3",
+                    "recordings": [
+                        {"name": "rec1", "segments": ["seg1"]},
+                        {"name": "rec2"},
+                    ],
+                },
+            ],
+        }
+        c2 = _create_corpus_with_structure(c2_structure)
+        c2.dump(c2_path)
+
+        # Merge the first and second corpora.
+        merged_corpus_path = os.path.join(tmpdir, "merged_corpus.xml.gz")
+        merge_corpora_job = MergeCorporaJob(
+            bliss_corpora=[Path(c1_path), Path(c2_path)],
+            name="custom_name_for_merged_corpus",
+            merge_strategy=MergeStrategy.MERGE_SUBCORPORA,
+        )
+        merge_corpora_job.out_merged_corpus = Path(merged_corpus_path)
+        merge_corpora_job.run()
+
+        merged_corpus = libcorpus.Corpus()
+        merged_corpus.load(merged_corpus_path)
+        expected_merged_corpus_structure = {
+            "name": "custom_name_for_merged_corpus",
+            "recordings": [
+                {"name": "rec1", "segments": ["seg10", "seg13"]},
+            ],
+            "subcorpora": [
+                {
+                    "name": "sc1",
+                    "recordings": [
+                        {"name": "rec1", "segments": ["seg1", "seg2", "seg3", "seg4", "seg5"]},
+                        {"name": "rec2", "segments": ["seg3", "seg4"]},
+                    ],
+                },
+                {
+                    "name": "sc2",
+                    "recordings": [
+                        {"name": "rec2", "segments": ["seg5"]},
+                        {"name": "rec3", "segments": ["seg6"]},
+                    ],
+                    "subcorpora": [
+                        {
+                            "name": "sc1",
+                            "recordings": [{"name": "rec1", "segments": ["seg1"]}],
+                        }
+                    ],
+                },
+                {
+                    "name": "sc3",
+                    "recordings": [
+                        {"name": "rec1", "segments": ["seg1"]},
+                        {"name": "rec2"},
+                    ],
+                },
+            ],
+        }
+        _check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -10,6 +10,7 @@ import i6_core.lib.corpus as libcorpus
 Path = setup_path(__package__)
 
 
+@pytest.mark.skip(reason="Private method only used in file.")
 def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corpus:
     """
     Creates a simple corpus from its definition in dictionary form.
@@ -40,6 +41,7 @@ def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corp
     return corpus
 
 
+@pytest.mark.skip(reason="Private method only used in file.")
 def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: dict[str, Any]) -> bool:
     """
     Asserts that the corpus passed as parameter has the same structure as the simple corpus dictionary provided.

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 import pytest
-from sisyphus import setup_path
+from sisyphus import setup_path, tk
 from i6_core.corpus.transform import MergeCorporaJob, MergeStrategy
 import i6_core.lib.corpus as libcorpus
 
@@ -11,7 +11,7 @@ Path = setup_path(__package__)
 
 
 @pytest.mark.skip(reason="Helper class only used in file.")
-class CorpusCreatorHelper:
+class _CorpusCreatorHelper:
     @staticmethod
     def _create_corpus_with_structure(corpus_dict: Dict[str, Any]) -> libcorpus.Corpus:
         """
@@ -38,7 +38,7 @@ class CorpusCreatorHelper:
                 recording.add_segment(segment)
             corpus.add_recording(recording)
         for subcorpus_dict in corpus_dict.get("subcorpora", []):
-            corpus.add_subcorpus(CorpusCreatorHelper._create_corpus_with_structure(subcorpus_dict))
+            corpus.add_subcorpus(_CorpusCreatorHelper._create_corpus_with_structure(subcorpus_dict))
 
         return corpus
 
@@ -84,63 +84,196 @@ class CorpusCreatorHelper:
         for subcorpus_dict in subcorpus_dicts:
             matching_subcorpus = [sc for sc in corpus.top_level_subcorpora() if sc.name == subcorpus_dict["name"]]
             assert (
-                len(matching_subcorpus) == 1
+                len(matching_subcorpus) <= 1
             ), f"There's more than one subcorpus matching for the subcorpus name {subcorpus_dict['name']}"
-            CorpusCreatorHelper._check_corpus_with_structure(matching_subcorpus[0], subcorpus_dict)
+            assert (
+                len(matching_subcorpus) != 0
+            ), f"There's no subcorpus matching for the subcorpus name {subcorpus_dict['name']}"
+            _CorpusCreatorHelper._check_corpus_with_structure(matching_subcorpus[0], subcorpus_dict)
 
         return True
 
 
-def test_merge_corpora_job_merge_recursive():
+@pytest.mark.skip(reason="Helper function only used in file.")
+def _create_non_overlapping_test_corpora(tmpdir: str) -> Tuple[Dict[str, Any], str, Dict[str, Any], str]:
     """
-    Merges two hardcoded corpora with the `MergeStrategy.MERGE_RECURSIVE` whose structures are the following:
+    Creates two corpus whose structures are the following:
 
-    CORPUS 1            CORPUS 2
-    rec1                rec1
-        seg10               seg13
-    sc1                 sc1
+    c1                  c2
+        rec1                rec2
+            seg10               seg13
+    ------------------------------------------
+        sc1                 sc2
+            rec3                sc1
+                seg1..2             rec4
+            rec5                        seg2..3
+                seg3..4
+
+    :param tmpdir: Directory in which to dump the corpora. The corpus names will be "c1.xml.gz" and "c2.xml.gz".
+    :return: Strings corresponding to the paths for the first and the second corpus, respectively.
+    """
+    # First corpus.
+    c1_path = os.path.join(tmpdir, "c1.xml.gz")
+    c1_structure = {
+        "name": "c1",
+        "recordings": [
+            {"name": "rec1", "segments": ["seg10"]},
+        ],
+        "subcorpora": [
+            {
+                "name": "sc1",
+                "recordings": [
+                    {"name": "rec3", "segments": ["seg1", "seg2"]},
+                    {"name": "rec5", "segments": ["seg3", "seg4"]},
+                ],
+            },
+        ],
+    }
+    c1 = _CorpusCreatorHelper._create_corpus_with_structure(c1_structure)
+    c1.dump(c1_path)
+
+    # Second corpus.
+    c2_path = os.path.join(tmpdir, "c2.xml.gz")
+    c2_structure = {
+        "name": "c2",
+        "recordings": [
+            {"name": "rec2", "segments": ["seg13"]},
+        ],
+        "subcorpora": [
+            {
+                "name": "sc2",
+                "subcorpora": [
+                    {
+                        "name": "sc1",
+                        "recordings": [{"name": "rec4", "segments": ["seg2", "seg3"]}],
+                    }
+                ],
+            },
+        ],
+    }
+    c2 = _CorpusCreatorHelper._create_corpus_with_structure(c2_structure)
+    c2.dump(c2_path)
+
+    return c1_structure, c1_path, c2_structure, c2_path
+
+
+@pytest.mark.skip(reason="Helper function only used in file.")
+def _create_overlapping_test_corpora(tmpdir: str) -> Tuple[Dict[str, Any], str, Dict[str, Any], str]:
+    """
+    Creates two corpus whose structures are the following:
+
+    c1                  c2
         rec1                rec1
-            seg1..2             seg3..5
-        rec2
-            seg3..4
-    ------------------------------------
-    sc2                 sc2
-        rec2
-            seg5
-        rec3
-            seg6
-                            sc1
+            seg10               seg13
+    ------------------------------------------
+        sc1                 sc1
+            rec1                rec1
+                seg1..2             seg3..5
+            rec2
+                seg3..4
+    ------------------------------------------
+        sc2                 sc2
+            rec2
+                seg5
+            rec3
+                seg6
+                                sc1
+                                    rec1
+                                        seg1
+    ------------------------------------------
+                            sc3
                                 rec1
                                     seg1
-    ------------------------------------
-                        sc3
-                            rec1
-                                seg1
-                            rec2
+                                rec2
 
-    The expected output structure is the following:
-    rec1
-        seg10
-        seg13
-    sc1
+    :param tmpdir: Directory in which to dump the corpora. The corpus names will be "c1.xml.gz" and "c2.xml.gz".
+    :return: Structures and paths (str) for the first and the second corpus, respectively.
+    """
+    # First corpus.
+    c1_path = os.path.join(tmpdir, "c1.xml.gz")
+    c1_structure = {
+        "name": "c1",
+        "recordings": [
+            {"name": "rec1", "segments": ["seg10"]},
+        ],
+        "subcorpora": [
+            {
+                "name": "sc1",
+                "recordings": [
+                    {"name": "rec1", "segments": ["seg1", "seg2"]},
+                    {"name": "rec2", "segments": ["seg3", "seg4"]},
+                ],
+            },
+            {
+                "name": "sc2",
+                "recordings": [
+                    {"name": "rec2", "segments": ["seg5"]},
+                    {"name": "rec3", "segments": ["seg6"]},
+                ],
+            },
+        ],
+    }
+    c1 = _CorpusCreatorHelper._create_corpus_with_structure(c1_structure)
+    c1.dump(c1_path)
+
+    # Second corpus.
+    c2_path = os.path.join(tmpdir, "c2.xml.gz")
+    c2_structure = {
+        "name": "c2",
+        "recordings": [
+            {"name": "rec1", "segments": ["seg13"]},
+        ],
+        "subcorpora": [
+            {"name": "sc1", "recordings": [{"name": "rec1", "segments": ["seg3", "seg4", "seg5"]}]},
+            {
+                "name": "sc2",
+                "subcorpora": [
+                    {
+                        "name": "sc1",
+                        "recordings": [{"name": "rec1", "segments": ["seg1"]}],
+                    }
+                ],
+            },
+            {
+                "name": "sc3",
+                "recordings": [
+                    {"name": "rec1", "segments": ["seg1"]},
+                    {"name": "rec2"},
+                ],
+            },
+        ],
+    }
+    c2 = _CorpusCreatorHelper._create_corpus_with_structure(c2_structure)
+    c2.dump(c2_path)
+
+    return c1_structure, c1_path, c2_structure, c2_path
+
+
+def test_merge_corpora_job_merge_recursive():
+    """
+    Merges two hardcoded corpora with the `MergeStrategy.MERGE_RECURSIVE`. The expected output structure is:
+
+    custom_name_for_merged_corpus
         rec1
-            seg1..5
-        rec2
-            seg3..4
-    ------------------------------------
-    sc2
-        rec2
-            seg5
-        rec3
-            seg6
+            seg10
+            seg13
         sc1
             rec1
+                seg1..5
+            rec2
+                seg3..4
+        sc2
+            rec2
+                seg5
+            rec3
+                seg6
+            sc1
+                rec1
+                    seg1
+        sc3
+            rec1
                 seg1
-    ------------------------------------
-    sc3
-        rec1
-            seg1
-        rec2
+            rec2
 
     Some notes about the expected output:
     `MergeStrategy.MERGE_RECURSIVE` only extends the segment list of the recordings.
@@ -150,62 +283,7 @@ def test_merge_corpora_job_merge_recursive():
     - It's intended that sc3/rec2 doesn't have any segments.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        # First corpus.
-        c1_path = os.path.join(tmpdir, "c1.xml.gz")
-        c1_structure = {
-            "name": "c1",
-            "recordings": [
-                {"name": "rec1", "segments": ["seg10"]},
-            ],
-            "subcorpora": [
-                {
-                    "name": "sc1",
-                    "recordings": [
-                        {"name": "rec1", "segments": ["seg1", "seg2"]},
-                        {"name": "rec2", "segments": ["seg3", "seg4"]},
-                    ],
-                },
-                {
-                    "name": "sc2",
-                    "recordings": [
-                        {"name": "rec2", "segments": ["seg5"]},
-                        {"name": "rec3", "segments": ["seg6"]},
-                    ],
-                },
-            ],
-        }
-        c1 = CorpusCreatorHelper._create_corpus_with_structure(c1_structure)
-        c1.dump(c1_path)
-
-        # Second corpus.
-        c2_path = os.path.join(tmpdir, "c2.xml.gz")
-        c2_structure = {
-            "name": "c2",
-            "recordings": [
-                {"name": "rec1", "segments": ["seg13"]},
-            ],
-            "subcorpora": [
-                {"name": "sc1", "recordings": [{"name": "rec1", "segments": ["seg3", "seg4", "seg5"]}]},
-                {
-                    "name": "sc2",
-                    "subcorpora": [
-                        {
-                            "name": "sc1",
-                            "recordings": [{"name": "rec1", "segments": ["seg1"]}],
-                        }
-                    ],
-                },
-                {
-                    "name": "sc3",
-                    "recordings": [
-                        {"name": "rec1", "segments": ["seg1"]},
-                        {"name": "rec2"},
-                    ],
-                },
-            ],
-        }
-        c2 = CorpusCreatorHelper._create_corpus_with_structure(c2_structure)
-        c2.dump(c2_path)
+        _, c1_path, _, c2_path = _create_overlapping_test_corpora(tmpdir)
 
         # Merge the first and second corpora.
         merged_corpus_path = os.path.join(tmpdir, "merged_corpus.xml.gz")
@@ -254,4 +332,116 @@ def test_merge_corpora_job_merge_recursive():
                 },
             ],
         }
-        CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)
+        _CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)
+
+
+def test_merge_corpora_job_merge_subcorpora():
+    """
+    Merges two hardcoded corpora with the `MergeStrategy.SUBCORPORA`. The expected output structure is the following:
+
+    custom_name_for_merged_corpus
+        <c1 as subcorpus>
+        <c2 as subcorpus>
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c1_structure, c1_path, c2_structure, c2_path = _create_overlapping_test_corpora(tmpdir)
+
+        # Merge the first and second corpora.
+        merged_corpus_path = os.path.join(tmpdir, "merged_corpus.xml.gz")
+        merge_corpora_job = MergeCorporaJob(
+            bliss_corpora=[Path(c1_path), Path(c2_path)],
+            name="custom_name_for_merged_corpus",
+            merge_strategy=MergeStrategy.SUBCORPORA,
+        )
+        merge_corpora_job.out_merged_corpus = Path(merged_corpus_path)
+        merge_corpora_job.run()
+
+        merged_corpus = libcorpus.Corpus()
+        merged_corpus.load(merged_corpus_path)
+        expected_merged_corpus_structure = {
+            "name": "custom_name_for_merged_corpus",
+            "subcorpora": [
+                c1_structure,
+                c2_structure,
+            ],
+        }
+        _CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)
+
+
+def test_merge_corpora_job_merge_flat():
+    """
+    Merges two hardcoded corpora with the `MergeStrategy.FLAT`. The expected output structure is the following:
+
+    custom_name_for_merged_corpus
+        rec1
+            seg10
+        rec2
+            seg13
+        rec3
+            seg1..2
+        rec4
+            seg2..3
+        rec5
+            seg3..4
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _, c1_path, _, c2_path = _create_non_overlapping_test_corpora(tmpdir)
+
+        # Merge the first and second corpora.
+        merged_corpus_path = os.path.join(tmpdir, "merged_corpus.xml.gz")
+        merge_corpora_job = MergeCorporaJob(
+            bliss_corpora=[Path(c1_path), Path(c2_path)],
+            name="custom_name_for_merged_corpus",
+            merge_strategy=MergeStrategy.FLAT,
+        )
+        merge_corpora_job.out_merged_corpus = Path(merged_corpus_path)
+        merge_corpora_job.run()
+
+        merged_corpus = libcorpus.Corpus()
+        merged_corpus.load(merged_corpus_path)
+        expected_merged_corpus_structure = {
+            "name": "custom_name_for_merged_corpus",
+            "recordings": [
+                {"name": "rec1", "segments": ["seg10"]},
+                {"name": "rec2", "segments": ["seg13"]},
+                {"name": "rec3", "segments": ["seg1", "seg2"]},
+                {"name": "rec4", "segments": ["seg2", "seg3"]},
+                {"name": "rec5", "segments": ["seg3", "seg4"]},
+            ],
+        }
+        _CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)
+
+
+def test_merge_corpora_job_merge_concatenate():
+    """
+    Merges two hardcoded corpora with the `MergeStrategy.CONCATENATE`. The expected output structure is the following:
+
+    custom_name_for_merged_corpus
+        <c1 as subcorpus>
+        <c2 as subcorpus>
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c1_structure, c1_path, c2_structure, c2_path = _create_non_overlapping_test_corpora(tmpdir)
+
+        # Merge the first and second corpora.
+        merged_corpus_path = os.path.join(tmpdir, "merged_corpus.xml.gz")
+        merge_corpora_job = MergeCorporaJob(
+            bliss_corpora=[Path(c1_path), Path(c2_path)],
+            name="custom_name_for_merged_corpus",
+            merge_strategy=MergeStrategy.CONCATENATE,
+        )
+        merge_corpora_job.out_merged_corpus = Path(merged_corpus_path)
+        merge_corpora_job.run()
+
+        merged_corpus = libcorpus.Corpus()
+        merged_corpus.load(merged_corpus_path)
+        expected_merged_corpus_structure = {
+            "name": "custom_name_for_merged_corpus",
+            "recordings": [
+                {"name": "rec1", "segments": ["seg10"]},
+                {"name": "rec2", "segments": ["seg13"]},
+            ],
+            "subcorpora": c1_structure["subcorpora"] + c2_structure["subcorpora"],
+        }
+        print(expected_merged_corpus_structure)
+        _CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
-from typing import Any, Optional
+from typing import Any
+import pytest
 from sisyphus import setup_path
-
 from i6_core.corpus.transform import MergeCorporaJob, MergeStrategy
 import i6_core.lib.corpus as libcorpus
 

--- a/tests/job_tests/corpus/test_transform.py
+++ b/tests/job_tests/corpus/test_transform.py
@@ -10,89 +10,90 @@ import i6_core.lib.corpus as libcorpus
 Path = setup_path(__package__)
 
 
-@pytest.mark.skip(reason="Private method only used in file.")
-def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corpus:
-    """
-    Creates a simple corpus from its definition in dictionary form.
-    The dictionary can have the following keys and with the respective type:
-    - "name": str
-    - "recordings": list[dict[str, Any]]: can have the following keys:
+@pytest.mark.skip(reason="Helper class only used in file.")
+class CorpusCreatorHelper:
+    @staticmethod
+    def _create_corpus_with_structure(corpus_dict: dict[str, Any]) -> libcorpus.Corpus:
+        """
+        Creates a simple corpus from its definition in dictionary form.
+        The dictionary can have the following keys and with the respective type:
         - "name": str
-        - "segments": list[str]
-    - "subcorpora": list[dict[str, Any]]: recursive definition of a corpus.
+        - "recordings": list[dict[str, Any]]: can have the following keys:
+            - "name": str
+            - "segments": list[str]
+        - "subcorpora": list[dict[str, Any]]: recursive definition of a corpus.
 
-    :param corpus_dict: Definition of a corpus in dictionary form.
-    :return: Corpus object defined by the corpus dictionary provided.
-    """
-    corpus = libcorpus.Corpus()
-    corpus.name = corpus_dict["name"]
-    for recording_dict in corpus_dict.get("recordings", []):
-        recording = libcorpus.Recording()
-        recording.name = recording_dict["name"]
-        for segment_name in recording_dict.get("segments", []):
-            segment = libcorpus.Segment()
-            segment.name = segment_name
-            segment.orth = ""
-            recording.add_segment(segment)
-        corpus.add_recording(recording)
-    for subcorpus_dict in corpus_dict.get("subcorpora", []):
-        corpus.add_subcorpus(_create_corpus_with_structure(subcorpus_dict))
+        :param corpus_dict: Definition of a corpus in dictionary form.
+        :return: Corpus object defined by the corpus dictionary provided.
+        """
+        corpus = libcorpus.Corpus()
+        corpus.name = corpus_dict["name"]
+        for recording_dict in corpus_dict.get("recordings", []):
+            recording = libcorpus.Recording()
+            recording.name = recording_dict["name"]
+            for segment_name in recording_dict.get("segments", []):
+                segment = libcorpus.Segment()
+                segment.name = segment_name
+                segment.orth = ""
+                recording.add_segment(segment)
+            corpus.add_recording(recording)
+        for subcorpus_dict in corpus_dict.get("subcorpora", []):
+            corpus.add_subcorpus(CorpusCreatorHelper._create_corpus_with_structure(subcorpus_dict))
 
-    return corpus
+        return corpus
 
+    @staticmethod
+    def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: dict[str, Any]) -> bool:
+        """
+        Asserts that the corpus passed as parameter has the same structure as the simple corpus dictionary provided.
 
-@pytest.mark.skip(reason="Private method only used in file.")
-def _check_corpus_with_structure(corpus: libcorpus.Corpus, corpus_dict: dict[str, Any]) -> bool:
-    """
-    Asserts that the corpus passed as parameter has the same structure as the simple corpus dictionary provided.
-
-    :param corpus: Corpus for which to check the structure.
-    :param corpus_dict: Expected corpus structure.
-    :return: True if the corpus matches the given structure.
-        Doesn't return False whenever the corpus structure doesn't match, but fails with an assertion.
-    """
-    # Check that the corpus name matches.
-    assert (
-        corpus.name == corpus_dict["name"]
-    ), f"Corpus name ({corpus.name}) doesn't coincide with provided ({corpus_dict['name']})."
-
-    # Check that the recordings (and their internal segments) match.
-    recordings_dicts = corpus_dict.get("recordings", [])
-    assert len(corpus.recordings) == len(recordings_dicts), (
-        f"Number of recordings in corpus ({len(corpus.recordings)}) not coinciding "
-        f"with provided ({len(recordings_dicts)})."
-    )
-    for recording_dict in recordings_dicts:
-        segments_from_dict = recording_dict.get("segments", [])
-
-        # Get the recording with the same name.
-        recordings_in_corpus_with_same_name = [
-            r for r in corpus.top_level_recordings() if r.name == recording_dict["name"]
-        ]
-        found_recording = None
-        for r in recordings_in_corpus_with_same_name:
-            if sorted([segment.name for segment in r.segments]) == sorted(segments_from_dict):
-                found_recording = r
-                break
+        :param corpus: Corpus for which to check the structure.
+        :param corpus_dict: Expected corpus structure.
+        :return: True if the corpus matches the given structure.
+            Doesn't return False whenever the corpus structure doesn't match, but fails with an assertion.
+        """
+        # Check that the corpus name matches.
         assert (
-            found_recording
-        ), f"No recording in {corpus.fullname()} found with the features provided by the user: {recording_dict}. "
+            corpus.name == corpus_dict["name"]
+        ), f"Corpus name ({corpus.name}) doesn't coincide with provided ({corpus_dict['name']})."
 
-    # Recursively check that the subcorpora match.
-    subcorpus_dicts = corpus_dict.get("subcorpora", [])
-    for subcorpus_dict in subcorpus_dicts:
-        matching_subcorpus = [sc for sc in corpus.top_level_subcorpora() if sc.name == subcorpus_dict["name"]]
-        assert (
-            len(matching_subcorpus) == 1
-        ), f"There's more than one subcorpus matching for the subcorpus name {subcorpus_dict['name']}"
-        _check_corpus_with_structure(matching_subcorpus[0], subcorpus_dict)
+        # Check that the recordings (and their internal segments) match.
+        recordings_dicts = corpus_dict.get("recordings", [])
+        assert len(corpus.recordings) == len(recordings_dicts), (
+            f"Number of recordings in corpus ({len(corpus.recordings)}) not coinciding "
+            f"with provided ({len(recordings_dicts)})."
+        )
+        for recording_dict in recordings_dicts:
+            segments_from_dict = recording_dict.get("segments", [])
 
-    return True
+            # Get the recording with the same name.
+            recordings_in_corpus_with_same_name = [
+                r for r in corpus.top_level_recordings() if r.name == recording_dict["name"]
+            ]
+            found_recording = None
+            for r in recordings_in_corpus_with_same_name:
+                if sorted([segment.name for segment in r.segments]) == sorted(segments_from_dict):
+                    found_recording = r
+                    break
+            assert (
+                found_recording
+            ), f"No recording in {corpus.fullname()} found with the features provided by the user: {recording_dict}. "
+
+        # Recursively check that the subcorpora match.
+        subcorpus_dicts = corpus_dict.get("subcorpora", [])
+        for subcorpus_dict in subcorpus_dicts:
+            matching_subcorpus = [sc for sc in corpus.top_level_subcorpora() if sc.name == subcorpus_dict["name"]]
+            assert (
+                len(matching_subcorpus) == 1
+            ), f"There's more than one subcorpus matching for the subcorpus name {subcorpus_dict['name']}"
+            CorpusCreatorHelper._check_corpus_with_structure(matching_subcorpus[0], subcorpus_dict)
+
+        return True
 
 
-def test_merge_corpora_job_merge_subcorpus_and_recordings():
+def test_merge_corpora_job_merge_recursive():
     """
-    Merges two hardcoded corpora with the `MergeStrategy.MERGE_SUBCORPORA` whose structures are the following:
+    Merges two hardcoded corpora with the `MergeStrategy.MERGE_RECURSIVE` whose structures are the following:
 
     CORPUS 1            CORPUS 2
     rec1                rec1
@@ -142,10 +143,10 @@ def test_merge_corpora_job_merge_subcorpus_and_recordings():
         rec2
 
     Some notes about the expected output:
-    `MergeStrategy.MERGE_SUBCORPORA` only extends the segment list of the recordings.
+    `MergeStrategy.MERGE_RECURSIVE` only extends the segment list of the recordings.
     - The nested subcorpus sc2/sc1 shouldn't be merged with the main subcorpus sc1.
     Moreover, its recording sc2/sc1/rec1 shouldn't be merged with neither rec1 nor sc1/rec1.
-    `MergeStrategy.MERGE_SUBCORPORA` only takes into consideration the top level subcorpora.
+    `MergeStrategy.MERGE_RECURSIVE` only takes into consideration the top level subcorpora.
     - It's intended that sc3/rec2 doesn't have any segments.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -173,7 +174,7 @@ def test_merge_corpora_job_merge_subcorpus_and_recordings():
                 },
             ],
         }
-        c1 = _create_corpus_with_structure(c1_structure)
+        c1 = CorpusCreatorHelper._create_corpus_with_structure(c1_structure)
         c1.dump(c1_path)
 
         # Second corpus.
@@ -203,7 +204,7 @@ def test_merge_corpora_job_merge_subcorpus_and_recordings():
                 },
             ],
         }
-        c2 = _create_corpus_with_structure(c2_structure)
+        c2 = CorpusCreatorHelper._create_corpus_with_structure(c2_structure)
         c2.dump(c2_path)
 
         # Merge the first and second corpora.
@@ -211,7 +212,7 @@ def test_merge_corpora_job_merge_subcorpus_and_recordings():
         merge_corpora_job = MergeCorporaJob(
             bliss_corpora=[Path(c1_path), Path(c2_path)],
             name="custom_name_for_merged_corpus",
-            merge_strategy=MergeStrategy.MERGE_SUBCORPORA,
+            merge_strategy=MergeStrategy.MERGE_RECURSIVE,
         )
         merge_corpora_job.out_merged_corpus = Path(merged_corpus_path)
         merge_corpora_job.run()
@@ -253,4 +254,4 @@ def test_merge_corpora_job_merge_subcorpus_and_recordings():
                 },
             ],
         }
-        _check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)
+        CorpusCreatorHelper._check_corpus_with_structure(merged_corpus, expected_merged_corpus_structure)


### PR DESCRIPTION
This new merge strategy flattens at the top level subcorpora, while merging recordings and segments with the same name.

Besides, I took the liberty to briefly comment what the rest of the merge strategies did.

If you want, before dumping I could sort the segments by start/end so that the final corpus is better structured.

Edit: my use case is splitting a big corpus into smaller subcorpora through `SegmentCorpusJob`/`FilterCorpusBySegmentsJob`, doing some work with the smaller subcorpora (that I haven't been able to parallelize, thus I split in smaller subcorpora), and then merging again through `MergeCorporaJob`. Then, I'd like the updated corpus to have the same shape as the original corpus, but none of the merging strategies for `MergeCorporaJob` does what I want. Regardless of whether my specific use case is valid or not, I think the functionality is useful.

Edit: `CONCATENATE` doesn't work because it duplicates the speakers inside the subcorpora, and doesn't merge the recordings.