### PR TITLE
Remove empty recordings in filtering jobs

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -363,7 +363,7 @@ class FilterCorpusBySegmentDurationJob(Job):
         bliss_corpus: Path,
         min_duration: float = 0.1,
         max_duration: float = 120.0,
-        delete_empty_recordings: bool = True,
+        delete_empty_recordings: bool = False,
     ):
         """
         :param bliss_corpus: path of the corpus file

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -252,21 +252,15 @@ class FilterCorpusBySegmentsJob(Job):
         c = corpus.Corpus()
         c.load(tk.uncached_path(self.bliss_corpus))
 
-        to_delete = []
         for rec in c.all_recordings():
             if self.invert_match:
                 rec.segments = [x for x in rec.segments if x.fullname() not in segments and x.name not in segments]
             else:
                 rec.segments = [x for x in rec.segments if x.fullname() in segments or x.name in segments]
 
-            if not rec.segments:
-                to_delete.append(rec)
-
         if self.delete_empty_recordings:
-            for rec in to_delete:
-                c.remove_recording(rec)
-            with open(self.out_removed_recordings, "w") as f:
-                f.write("\n".join(rec.fullname() for rec in to_delete))
+            # Remove the recordings without segments due to the filtering.
+            _delete_empty_recordings(c, self.out_removed_recordings.get_path())
 
         c.dump(tk.uncached_path(self.out_corpus))
 


### PR DESCRIPTION
This PR adds behavior to remove recordings that are left empty due to the filtering performed. It affects the `FilterCorpusBySegmentDurationJob` and the `FilterCorpusRemoveUnknownWordSegmentsJob`.