### PR TITLE
SpellingConversion: Keeping target lemmas in case of both variants in the LM.

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -471,9 +471,9 @@ class SpellingConversionJob(Job):
             else:
                 logging.info("No source lemma for: {}".format(source_orth))
             if target_lemma:
+                if self.keep_original_target_lemmas:
+                    copy_target_lemma = copy.deepcopy(target_lemma)
                 if source_lemma:
-                    if self.keep_original_target_lemmas:
-                        copy_target_lemma = copy.deepcopy(target_lemma)
                     for orth in source_lemma.orth:
                         if orth not in target_lemma.orth:
                             target_lemma.orth.append(orth)
@@ -498,6 +498,9 @@ class SpellingConversionJob(Job):
                         target_lemma.synt = source_lemma.synt
                     else:
                         target_lemma.synt = source_orth.split()
+                        if self.keep_original_target_lemmas:
+                            target_position = lex.lemmata.index(target_lemma)
+                            lex.lemmata.insert(target_position - 1, copy_target_lemma)
                 logging.info(self._lemma_to_str(target_lemma, "final lemma"))
             elif source_lemma:
                 source_lemma.orth.insert(0, target_orth)

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -498,9 +498,9 @@ class SpellingConversionJob(Job):
                         target_lemma.synt = source_lemma.synt
                     else:
                         target_lemma.synt = source_orth.split()
-                        if self.keep_original_target_lemmas:
-                            target_position = lex.lemmata.index(target_lemma)
-                            lex.lemmata.insert(target_position - 1, copy_target_lemma)
+                if self.keep_original_target_lemmas and not source_lemma:
+                    target_position = lex.lemmata.index(target_lemma)
+                    lex.lemmata.insert(target_position - 1, copy_target_lemma)
                 logging.info(self._lemma_to_str(target_lemma, "final lemma"))
             elif source_lemma:
                 source_lemma.orth.insert(0, target_orth)


### PR DESCRIPTION
Hi all,
I have another use-case where I need a fix for this job :sweat_smile: 

For our EN_US lexicon we have British and US spelling but instead of mapping EVERYTHING to UK spelling in the synt token and removing the correct US lemmas:
```
converted.old.lexicon.xml.gz-  <lemma>
converted.old.lexicon.xml.gz:    <orth>acclimatization</orth>
converted.old.lexicon.xml.gz-    <orth>acclimatisation</orth>
converted.old.lexicon.xml.gz-    <phon>ə k l aɪ m ə t ɪ z eɪ ʃ ɪ n</phon>
converted.old.lexicon.xml.gz-    <synt>
converted.old.lexicon.xml.gz-      <tok>acclimatisation</tok>
converted.old.lexicon.xml.gz-    </synt>
converted.old.lexicon.xml.gz-  </lemma>
```
we want to also keep this original lemma like it is:
```
converted.old.lexicon.xml.gz-  <lemma>
converted.old.lexicon.xml.gz:    <orth>acclimatization</orth>
converted.old.lexicon.xml.gz-    <phon>ə k l aɪ m ə t ɪ z eɪ ʃ ɪ n</phon>
converted.old.lexicon.xml.gz-  </lemma>
```

In this way we benefit from the whole data the lm is trained on, but we make sure the ASR system outputs the correct spelling.
