### PR TITLE
SpellingConversionJob: allow Path as input otherwise breaks hashes.

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -349,10 +349,7 @@ class SpellingConversionJob(Job):
         self.set_vis_name("Convert Between Regional Orth Spellings")
 
         self.bliss_lexicon = bliss_lexicon
-        if isinstance(orth_mapping_file, tk.Path):
-            self.orth_mapping_file = orth_mapping_file.get_path()
-        else:
-            self.orth_mapping_file = orth_mapping_file
+        self.orth_mapping_file = orth_mapping_file
         self.invert_mapping = invert_mapping
         self.mapping_file_delimiter = mapping_file_delimiter
         self.mapping_rules = mapping_rules
@@ -380,16 +377,16 @@ class SpellingConversionJob(Job):
 
     def run(self):
         # load mapping from json or plain text file
-        is_json = self.orth_mapping_file.endswith(".json")
-        is_json |= self.orth_mapping_file.endswith(".json.gz")
+        orth_map_file_str = tk.uncached_path(self.orth_mapping_file)
+        is_json = orth_map_file_str.endswith(".json") | orth_map_file_str.endswith(".json.gz")
         if is_json:
-            with uopen(self.orth_mapping_file, "rt") as f:
+            with uopen(orth_map_file_str, "rt") as f:
                 mapping = json.load(f)
             if self.invert_mapping:
                 mapping = {v: k for k, v in mapping.items()}
         else:
             mapping = dict()
-            with uopen(self.orth_mapping_file, "rt") as f:
+            with uopen(orth_map_file_str, "rt") as f:
                 for line in f:
                     line = line.strip()
                     if not line or line.startswith("#"):

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os.path
 import re
+from typing import List, Optional, Tuple, Union
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
@@ -308,18 +309,18 @@ class SpellingConversionJob(Job):
 
     def __init__(
         self,
-        bliss_lexicon,
-        orth_mapping_file,
-        mapping_file_delimiter=" ",
-        mapping_rules=None,
-        invert_mapping=False,
-        keep_original_target_lemmas=False,
+        bliss_lexicon: tk.Path,
+        orth_mapping_file: Union[str, tk.Path],
+        mapping_file_delimiter: str = " ",
+        mapping_rules: Optional[List[Tuple[str, str, str]]] = None,
+        invert_mapping: bool = False,
+        keep_original_target_lemmas: bool = False,
     ):
         """
         :param Path bliss_lexicon:
             input lexicon, whose lemmata all have unique PRIMARY orth
             to reach the above requirements apply LexiconUniqueOrthJob
-        :param str orth_mapping_file:
+        :param str|tk.Path orth_mapping_file:
             orthography mapping file: *.json *.json.gz *.txt *.gz
             in case of plain text file
                 one can adjust mapping_delimiter
@@ -348,7 +349,10 @@ class SpellingConversionJob(Job):
         self.set_vis_name("Convert Between Regional Orth Spellings")
 
         self.bliss_lexicon = bliss_lexicon
-        self.orth_mapping_file = orth_mapping_file
+        if isinstance(orth_mapping_file, tk.Path):
+            self.orth_mapping_file = orth_mapping_file.get_path()
+        else:
+            self.orth_mapping_file = orth_mapping_file
         self.invert_mapping = invert_mapping
         self.mapping_file_delimiter = mapping_file_delimiter
         self.mapping_rules = mapping_rules


### PR DESCRIPTION
If the spelling conversion mapping file is created by another job we can not just parse the string with `get_path() `without breaking hashes in our `apptek_asr` pipeline.
Therefore adding the option to give the file as a `tk.Path.`