### PR TITLE
Improvements to recording removal

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -35,8 +35,7 @@ def _delete_empty_recordings(corpus: corpus.Corpus, removed_recordings_file: str
         if not rec.segments:
             to_delete.append(rec)
 
-    for rec in to_delete:
-        corpus.remove_recording(rec)
+    corpus.remove_recordings(to_delete)
     with open(removed_recordings_file, "w") as f:
         f.write("\n".join(rec.fullname() for rec in to_delete))
 

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -35,10 +35,10 @@ def _delete_empty_recordings(corpus: corpus.Corpus, removed_recordings_file: str
         if not rec.segments:
             to_delete.append(rec)
 
-        for rec in to_delete:
-            corpus.remove_recording(rec)
-        with open(removed_recordings_file, "w") as f:
-            f.write("\n".join(rec.fullname() for rec in to_delete))
+    for rec in to_delete:
+        corpus.remove_recording(rec)
+    with open(removed_recordings_file, "w") as f:
+        f.write("\n".join(rec.fullname() for rec in to_delete))
 
 
 class FilterSegmentsByListJob(Job):

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -204,6 +204,17 @@ class Corpus(NamedEntity, CorpusSection):
         for sc in self.subcorpora:
             sc.remove_recording(recording)
 
+    def remove_recordings(self, recordings: List[Recording]):
+        recording_fullnames = {recording.fullname() for recording in recordings}
+        to_delete = []
+        for idx, r in enumerate(self.recordings):
+            if r.fullname() in recording_fullnames:
+                to_delete.append(idx)
+        for idx in reversed(to_delete):
+            del self.recordings[idx]
+        for sc in self.subcorpora:
+            sc.remove_recordings(recordings)
+
     def add_recording(self, recording: Recording):
         assert isinstance(recording, Recording)
         recording.corpus = self


### PR DESCRIPTION
In https://github.com/rwth-i6/i6_core/pull/497 I introduced a big inefficiency by indenting one level inwards the recording removal step. That's fixed now.

Besides, I've added a function to remove a list of recordings based on their fullname, and I've used it in the empty recording filtering.