### PR TITLE
Add plots to AlignmentJob

### DIFF
--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -157,9 +157,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         logging.info(
             f"Max {np_alignment_scores.max()}; min {np_alignment_scores.min()}; median {np.median(np_alignment_scores)}"
         )
-        logging.info(
-            f"Total number of segments: {np_alignment_scores.size}; 90-th percentile: {higher_percentile.size}"
-        )
+        logging.info(f"Total number of segments: {np_alignment_scores.size}; 90-th percentile: {higher_percentile}")
 
         # Plot the data.
         matplotlib.use("Agg")

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -20,7 +20,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
     Align a dataset with the given feature scorer.
     """
 
-    __sis_hash_exclude__ = {"plot_alignment_scores": True}
+    __sis_hash_exclude__ = {"plot_alignment_scores": False}
 
     def __init__(
         self,
@@ -33,7 +33,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         rtf=1.0,
         extra_config=None,
         extra_post_config=None,
-        plot_alignment_scores=True,
+        plot_alignment_scores=False,
     ):
         """
         :param rasr.crp.CommonRasrParameters crp:
@@ -46,6 +46,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         :param extra_config:
         :param extra_post_config:
         :param plot_alignment_scores: Whether to plot the alignment scores (normalized over time) or not.
+            The recommended value is `True`. The default value is `False` for retrocompatibility purposes.
         """
         assert isinstance(feature_scorer, rasr.FeatureScorer)
 

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -153,13 +153,16 @@ class AlignmentJob(rasr.RasrCommand, Job):
             del document
 
         np_alignment_scores = np.asarray(alignment_scores)
+        higher_percentile = np.percentile(np_alignment_scores, 90)  # There can be huge outliers.
         logging.info(
-            f"Max {np_alignment_scores.max()}; Min {np_alignment_scores.min()}; Median {np.median(np_alignment_scores)}"
+            f"Max {np_alignment_scores.max()}; min {np_alignment_scores.min()}; median {np.median(np_alignment_scores)}"
+        )
+        logging.info(
+            f"Total number of segments: {np_alignment_scores.size}; 90-th percentile: {higher_percentile.size}"
         )
 
         # Plot the data.
         matplotlib.use("Agg")
-        higher_percentile = np.percentile(np_alignment_scores, 90)  # There can be huge outliers.
         np.clip(np_alignment_scores, np_alignment_scores.min(), higher_percentile, out=np_alignment_scores)
         plt.hist(np_alignment_scores, bins=100)
         plt.xlabel("Average Maximum-Likelihood Score")

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -144,7 +144,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         alignment_scores = []
         for log_file in self.out_log_file.values():
             logging.info("Reading: {}".format(log_file))
-            file_path = tk.uncached_path(log_file)
+            file_path = log_file.get_path()
             document = ET.parse(util.uopen(file_path))
             _seg_list = document.findall(".//segment")
             for seg in _seg_list:

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -1,5 +1,6 @@
 __all__ = ["AlignmentJob", "DumpAlignmentJob", "AMScoresFromAlignmentLogJob"]
 
+import logging
 import xml.etree.ElementTree as ET
 import math
 import os
@@ -26,6 +27,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         rtf=1.0,
         extra_config=None,
         extra_post_config=None,
+        plot_alignment_scores=True,
     ):
         """
         :param rasr.crp.CommonRasrParameters crp:
@@ -37,6 +39,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         :param float rtf:
         :param extra_config:
         :param extra_post_config:
+        :param plot_alignment_scores: Whether to plot the alignment scores (normalized over time) or not.
         """
         assert isinstance(feature_scorer, rasr.FeatureScorer)
 
@@ -52,6 +55,7 @@ class AlignmentJob(rasr.RasrCommand, Job):
         self.feature_scorer = feature_scorer
         self.use_gpu = use_gpu
         self.word_boundaries = word_boundaries
+        self.plot_alignment_scores = plot_alignment_scores
 
         self.out_log_file = self.log_file_output_path("alignment", crp, True)
         self.out_single_alignment_caches = dict(
@@ -75,6 +79,8 @@ class AlignmentJob(rasr.RasrCommand, Job):
                 cached=True,
             )
             self.out_word_boundary_bundle = self.output_path("word_boundary.cache.bundle", cached=True)
+        if self.plot_alignment_scores:
+            self.out_plot_avg = self.output_path("score.png")
 
         self.rqmt = {
             "time": max(rtf * crp.corpus_duration / crp.concurrent, 0.5),
@@ -91,6 +97,8 @@ class AlignmentJob(rasr.RasrCommand, Job):
 
         yield Task("create_files", mini_task=True)
         yield Task("run", resume="run", rqmt=rqmt, args=range(1, self.concurrent + 1))
+        if self.plot_alignment_scores:
+            yield Task("plot", resume="plot", rqmt=rqmt)
 
     def create_files(self):
         self.write_config(self.config, self.post_config, "alignment.config")
@@ -120,6 +128,36 @@ class AlignmentJob(rasr.RasrCommand, Job):
                 "word_boundary.cache.%d" % task_id,
                 self.out_single_word_boundary_caches[task_id].get_path(),
             )
+
+    def plot(self):
+        import numpy as np
+        import matplotlib
+        import matplotlib.pyplot as plt
+
+        # Parse the files and search for the average alignment score values (normalized over time).
+        alignment_scores = []
+        for log_file in self.out_log_file.values():
+            logging.info("Reading: {}".format(log_file))
+            file_path = tk.uncached_path(log_file)
+            document = ET.parse(util.uopen(file_path))
+            _seg_list = document.findall(".//segment")
+            for seg in _seg_list:
+                avg = seg.find(".//score/avg")
+                alignment_scores.append(float(avg.text))
+            del document
+
+        np_alignment_scores = np.asarray(alignment_scores)
+        logging.info(
+            f"Max {np_alignment_scores.max()}; Min {np_alignment_scores.min()}; Median {np.median(np_alignment_scores)}"
+        )
+
+        # Plot the data.
+        matplotlib.use("Agg")
+        plt.hist(np_alignment_scores, bins=100)
+        plt.xlabel("Average Maximum-Likelihood Score")
+        plt.ylabel("Number of Segments")
+        plt.title("Histogram of Alignment Scores")
+        plt.savefig(fname=self.out_plot_avg.get_path())
 
     def cleanup_before_run(self, cmd, retry, task_id, *args):
         util.backup_if_exists("alignment.log.%d" % task_id)

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -159,6 +159,8 @@ class AlignmentJob(rasr.RasrCommand, Job):
 
         # Plot the data.
         matplotlib.use("Agg")
+        higher_percentile = np.percentile(np_alignment_scores, 90)  # There can be huge outliers.
+        np.clip(np_alignment_scores, np_alignment_scores.min(), higher_percentile, out=np_alignment_scores)
         plt.hist(np_alignment_scores, bins=100)
         plt.xlabel("Average Maximum-Likelihood Score")
         plt.ylabel("Number of Segments")

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -16,6 +16,12 @@ import i6_core.util as util
 
 
 class AlignmentJob(rasr.RasrCommand, Job):
+    """
+    Align a dataset with the given feature scorer.
+    """
+
+    __sis_hash_exclude__ = {"plot_alignment_scores": True}
+
     def __init__(
         self,
         crp,


### PR DESCRIPTION
Plots have only been added to `i6_core.corpus.filter.FilterSegmentsByAlignmentConfidenceJob`. However, it's useful to see the alignment score plot before actually filtering it. This PR adds optional (but recommended, given the default value of the `plot_alignment_scores` parameter) functionality to `i6_core.mm.AlignmentJob`.

Edit: the plotting is improved with respect to the former job in the sense that the former job only handled positive numbers between 0 and 200, while the current code can handle all ranges of numbers. This is useful, for instance, when aligning with a neural-network-based feature scorer that outputs log-probabilities as alignment scores.

Note that even if the functionality of the previous jobs changes, the practical output result is the same: whoever ignored plots because they used the job prior to this PR can ignore them, and whoever uses the plots from now on won't suffer any consequence.

I've also made it so that hashes don't change either.