### PR TITLE
CorpusObject: add parameters to init

### DIFF
--- a/meta/system.py
+++ b/meta/system.py
@@ -40,10 +40,10 @@ class CorpusObject(tk.Object):
         duration: Optional[float] = None,
     ):
         """
-        self.corpus_file: Bliss corpus xml
-        self.audio_dir: Audio directory if paths are relative (usually not needed)
-        self.audio_format: Format type of the audio files, see e.g. get_input_node_type()
-        self.duration: Duration of the corpus, is used to determine job time
+        :param corpus_file: Bliss corpus xml
+        :param audio_dir: Audio directory if paths are relative (usually not needed)
+        :param audio_format: Format type of the audio files, see e.g. get_input_node_type()
+        :param duration: Duration of the corpus, is used to determine job time
         """
         self.corpus_file = corpus_file
         self.audio_dir = audio_dir

--- a/meta/system.py
+++ b/meta/system.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ["System", "select_element", "CorpusObject"]
 
 import copy
+from dataclasses import dataclass
 import types
 from typing import Any, Dict, List, Optional, Tuple, Union
 import re
@@ -27,28 +28,16 @@ Path = setup_path(__package__)
 selector_type = Union[str, List, Tuple[str], Tuple[str, str], Tuple[str, str, int]]
 
 
-class CorpusObject(tk.Object):
+@dataclass
+class CorpusObject:
     """
     A simple container object to track additional information for a bliss corpus
     """
 
-    def __init__(
-        self,
-        corpus_file: Optional[tk.Path] = None,
-        audio_dir: Optional[tk.Path] = None,
-        audio_format: Optional[str] = None,
-        duration: Optional[float] = None,
-    ):
-        """
-        :param corpus_file: Bliss corpus xml
-        :param audio_dir: Audio directory if paths are relative (usually not needed)
-        :param audio_format: Format type of the audio files, see e.g. get_input_node_type()
-        :param duration: Duration of the corpus, is used to determine job time
-        """
-        self.corpus_file = corpus_file
-        self.audio_dir = audio_dir
-        self.audio_format = audio_format
-        self.duration = duration
+    corpus_file: Optional[tk.Path] = None  # Bliss corpus xml
+    audio_dir: Optional[tk.Path] = None  # Audio directory if paths are relative (usually not needed)
+    audio_format: Optional[str] = None  # Format type of the audio files, see e.g. get_input_node_type()
+    duration: Optional[float] = None  # Duration of the corpus, is used to determine job time
 
 
 class System:

--- a/meta/system.py
+++ b/meta/system.py
@@ -32,11 +32,23 @@ class CorpusObject(tk.Object):
     A simple container object to track additional information for a bliss corpus
     """
 
-    def __init__(self):
-        self.corpus_file: Optional[tk.Path] = None  # bliss corpus xml
-        self.audio_dir: Optional[tk.Path] = None  # audio directory if paths are relative (usually not needed)
-        self.audio_format: Optional[str] = None  # format type of the audio files, see e.g. get_input_node_type()
-        self.duration: Optional[float] = None  # duration of the corpus, is used to determine job time
+    def __init__(
+        self,
+        corpus_file: Optional[tk.Path] = None,
+        audio_dir: Optional[tk.Path] = None,
+        audio_format: Optional[str] = None,
+        duration: Optional[float] = None,
+    ):
+        """
+        self.corpus_file: Bliss corpus xml
+        self.audio_dir: Audio directory if paths are relative (usually not needed)
+        self.audio_format: Format type of the audio files, see e.g. get_input_node_type()
+        self.duration: Duration of the corpus, is used to determine job time
+        """
+        self.corpus_file = corpus_file
+        self.audio_dir = audio_dir
+        self.audio_format = audio_format
+        self.duration = duration
 
 
 class System:


### PR DESCRIPTION
I find it much better to provide the parameters to an object via `__init__` than to provide them by creating the object and explicitly setting the actual attribute. This helps for instance when I have to create a bunch of `CorpusObject`s in a list comprehension, which is similar to my use case.

If there was any explicit reason why these were not in the `__init__` function please let me know.