### PR TITLE
Add `GetOovRateJob`

### DIFF
--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -209,7 +209,7 @@ class GetOovRateJob(Job):
 
         self.out_oov_rate = self.output_var("oov_rate")
 
-        self.rqmt = {"cpu": 1, "mem": 5.0, "time": 2.0}
+        self.rqmt = {"cpu": 1, "mem": 1.0, "time": 2.0}
 
     def tasks(self):
         yield Task("run", resume="run", rqmt=self.rqmt)

--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -215,10 +215,8 @@ class GetOovRateJob(Job):
         yield Task("run", resume="run", rqmt=self.rqmt)
 
     def run(self):
-        vocab = set()
         with uopen(self.vocab_file.get_path(), "rt") as in_vocab:
-            for word in in_vocab:
-                vocab.add(word.strip())
+            vocab = set(word.strip() for word in in_vocab)
 
         total_words = 0
         oov_words = 0


### PR DESCRIPTION
Adds the `GetOovRateJob`, which computes the OOV rate of a text file with respect to a given vocabulary.

This is motivated by the lack of jobs that perform this basic operation, and by the complexity of manually having to tinker with the outputs of already existing tools in order to get this number.

If there was a job that already did this, please let me know.