### PR TITLE
ReturnnDumpHDFJob: Add read permissions for all on produced HDF file

### DIFF
--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -112,6 +112,7 @@ class ReturnnDumpHDFJob(Job):
             args += ["--epoch", f"{self.epoch}"]
 
         sp.check_call(args)
+        os.chmod(tmp_hdf_file, 644)
         shutil.move(tmp_hdf_file, self.out_hdf.get_path())
 
     @classmethod


### PR DESCRIPTION
The `tempfile.mkstemp` function creates the temporary file with permissions `-rw-------`.
This is undesirable because it prohibits sharing the produced hdfs with others.

This PR changes the permissions to `-rw-r--r--` 