### PR TITLE
remove broken __sis_hash_exclude

### DIFF
--- a/text/processing.py
+++ b/text/processing.py
@@ -120,8 +120,6 @@ class ConcatenateJob(Job):
     Concatenate all given input files (gz or raw)
     """
 
-    __sis_hash_exclude = {"zip_out": True, "out_name": "out"}
-
     def __init__(self, text_files: List[Path], zip_out: bool = True, out_name: str = "out"):
         """
         :param text_files: input text files


### PR DESCRIPTION
This is not doing anything except confuse people who copy-paste it (#535)

As this has been broken for over 3 years now, I would just remove it.