### PR TITLE
Fix dumped HDF permissions

### DIFF
--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -112,7 +112,7 @@ class ReturnnDumpHDFJob(Job):
             args += ["--epoch", f"{self.epoch}"]
 
         sp.check_call(args)
-        os.chmod(tmp_hdf_file, 644)
+        os.chmod(tmp_hdf_file, 0o644)
         shutil.move(tmp_hdf_file, self.out_hdf.get_path())
 
     @classmethod


### PR DESCRIPTION
The permission number is interpreted bitwise and needs to be given in octal.

Decimal 644 is interpreted as 1204, which is entirely not desired.

Kudos to @Max-Ryujin for spotting the problem and testing the fix.