### PR TITLE
Drop optional CTM n-best header

### DIFF
--- a/returnn/search.py
+++ b/returnn/search.py
@@ -449,7 +449,7 @@ class SearchWordsToCTMJob(Job):
         d = eval(util.uopen(self.recog_words_file.get_path(), "rt").read())
         assert isinstance(d, dict), "only search output file with dict format is supported"
         with util.uopen(self.out_ctm_file.get_path(), "wt") as out:
-            out.write(";; <name> <track> <start> <duration> <word> <confidence> [<n-best>]\n")
+            out.write(";; <name> <track> <start> <duration> <word> <confidence>\n")
             for seg in corpus.segments():
                 seg_start = 0.0 if seg.start == float("inf") else seg.start
                 seg_end = 0.0 if seg.end == float("inf") else seg.end
@@ -541,7 +541,7 @@ class SearchWordsDummyTimesToCTMJob(Job):
         else:
             seq_order = d.keys()
         with util.uopen(self.out_ctm_file.get_path(), "wt") as out:
-            out.write(";; <name> <track> <start> <duration> <word> <confidence> [<n-best>]\n")
+            out.write(";; <name> <track> <start> <duration> <word> <confidence>\n")
             for seg_fullname in seq_order:
                 assert isinstance(
                     seg_fullname, str

--- a/returnn/search.py
+++ b/returnn/search.py
@@ -449,6 +449,11 @@ class SearchWordsToCTMJob(Job):
         d = eval(util.uopen(self.recog_words_file.get_path(), "rt").read())
         assert isinstance(d, dict), "only search output file with dict format is supported"
         with util.uopen(self.out_ctm_file.get_path(), "wt") as out:
+            # Do not print optional [n-best] header, some downstream evaluation pipelines
+            # use the number of headers for validation. Since we do not print n-best-list
+            # information this validation fails and discards the entire search outputs.
+            #
+            # See https://github.com/rwth-i6/i6_core/pull/542.
             out.write(";; <name> <track> <start> <duration> <word> <confidence>\n")
             for seg in corpus.segments():
                 seg_start = 0.0 if seg.start == float("inf") else seg.start
@@ -541,6 +546,11 @@ class SearchWordsDummyTimesToCTMJob(Job):
         else:
             seq_order = d.keys()
         with util.uopen(self.out_ctm_file.get_path(), "wt") as out:
+            # Do not print optional [n-best] header, some downstream evaluation pipelines
+            # use the number of headers for validation. Since we do not print n-best-list
+            # information this validation fails and discards the entire search outputs.
+            #
+            # See https://github.com/rwth-i6/i6_core/pull/542.
             out.write(";; <name> <track> <start> <duration> <word> <confidence>\n")
             for seg_fullname in seq_order:
                 assert isinstance(


### PR DESCRIPTION
This optional header fields leads to issues in GLM mapping, resulting in high (almost 100 percent) deletion rates, because all lines with fewer than 7 columns are dropped from the file.