### PR TITLE
Add `f32` support when reading RASR caches

### DIFF
--- a/lib/rasr_cache.py
+++ b/lib/rasr_cache.py
@@ -928,7 +928,7 @@ class MixtureSet:
             self.densities[n, 1] = cov_idx
 
         self.num_mixtures = self.read_u32()
-        self.mixtures: List[Optional[Tuple[List[int], List[float]]]] = [None] * self.num_mixtures  # nopep8
+        self.mixtures: List[Optional[Tuple[List[int], List[float]]]] = [None] * self.num_mixtures
         for n in range(self.num_mixtures):
             num_densities = self.read_u32()
             dns_idx = []

--- a/lib/rasr_cache.py
+++ b/lib/rasr_cache.py
@@ -331,7 +331,6 @@ class FileArchive:
             # print(typ)
             assert typ in {"vector-f32", "f32"}
             count = self.read_U32()
-            print(f"count: {count}")
             data = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
             time_ = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
             if typ == "vector-f32":
@@ -341,12 +340,8 @@ class FileArchive:
                     time_[i] = self.read_v("d", 2)  # 2    x f64
             elif typ == "f32":
                 for i in range(count):
-                    #size = self.read_U32()
-                    #print(f"size = {size}")
-                    data[i] = self.read_v("f", 1)  # size x f32
-                    print(f"data = {data[i]}")
-                    time_[i] = self.read_v("d", 2)  # 2    x f64
-                    print(f"time = {time_[i]}")
+                    data[i] = self.read_v("f", 1)  # 1 x f32
+                    time_[i] = self.read_v("d", 2)  # 2 x f64
             return time_, data
         elif typ in ["align", "align_raw"]:
             type_len = self.read_U32()

--- a/lib/rasr_cache.py
+++ b/lib/rasr_cache.py
@@ -329,14 +329,24 @@ class FileArchive:
             type_len = self.read_U32()
             typ = self.read_str(type_len)
             # print(typ)
-            assert typ == "vector-f32"
+            assert typ in {"vector-f32", "f32"}
             count = self.read_U32()
+            print(f"count: {count}")
             data = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
             time_ = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
-            for i in range(count):
-                size = self.read_U32()
-                data[i] = self.read_v("f", size)  # size x f32
-                time_[i] = self.read_v("d", 2)  # 2    x f64
+            if typ == "vector-f32":
+                for i in range(count):
+                    size = self.read_U32()
+                    data[i] = self.read_v("f", size)  # size x f32
+                    time_[i] = self.read_v("d", 2)  # 2    x f64
+            elif typ == "f32":
+                for i in range(count):
+                    #size = self.read_U32()
+                    #print(f"size = {size}")
+                    data[i] = self.read_v("f", 1)  # size x f32
+                    print(f"data = {data[i]}")
+                    time_[i] = self.read_v("d", 2)  # 2    x f64
+                    print(f"time = {time_[i]}")
             return time_, data
         elif typ in ["align", "align_raw"]:
             type_len = self.read_U32()
@@ -923,9 +933,7 @@ class MixtureSet:
             self.densities[n, 1] = cov_idx
 
         self.num_mixtures = self.read_u32()
-        self.mixtures = [
-            None
-        ] * self.num_mixtures  # type: typing.List[typing.Optional[typing.Tuple[typing.List[int],typing.List[float]]]]  # nopep8
+        self.mixtures = [None] * self.num_mixtures  # type: typing.List[typing.Optional[typing.Tuple[typing.List[int],typing.List[float]]]]  # nopep8
         for n in range(self.num_mixtures):
             num_densities = self.read_u32()
             dns_idx = []

--- a/lib/rasr_cache.py
+++ b/lib/rasr_cache.py
@@ -13,7 +13,7 @@ import logging
 import mmap
 import numpy
 import os
-import typing
+from typing import Dict, List, Optional, Tuple
 import zlib
 from struct import pack, unpack
 
@@ -53,7 +53,7 @@ class FileArchive:
     def __init__(self, filename, must_exists=False, encoding="ascii"):
         self.encoding = encoding
 
-        self.ft = {}  # type: typing.Dict[str,FileInfo]
+        self.ft: Dict[str, FileInfo] = {}
         if os.path.exists(filename):
             self.allophones = []
             self.f = open(filename, "rb")
@@ -331,8 +331,8 @@ class FileArchive:
             # print(typ)
             assert typ in {"vector-f32", "f32"}
             count = self.read_U32()
-            data = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
-            time_ = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
+            data: List[Optional[numpy.ndarray]] = [None] * count
+            time_: List[Optional[numpy.ndarray]] = [None] * count
             if typ == "vector-f32":
                 for i in range(count):
                     size = self.read_U32()
@@ -572,9 +572,9 @@ class FileArchiveBundle:
         :param str encoding: encoding used in the files
         """
         # filename -> FileArchive
-        self.archives = {}  # type: typing.Dict[str,FileArchive]
+        self.archives: Dict[str, FileArchive] = {}
         # archive content file -> FileArchive
-        self.files = {}  # type: typing.Dict[str,FileArchive]
+        self.files: Dict[str, FileArchive] = {}
         self._short_seg_names = {}
         for line in open(filename).read().splitlines():
             self.archives[line] = a = FileArchive(line, must_exists=True, encoding=encoding)
@@ -928,7 +928,7 @@ class MixtureSet:
             self.densities[n, 1] = cov_idx
 
         self.num_mixtures = self.read_u32()
-        self.mixtures = [None] * self.num_mixtures  # type: typing.List[typing.Optional[typing.Tuple[typing.List[int],typing.List[float]]]]  # nopep8
+        self.mixtures: List[Optional[Tuple[List[int], List[float]]]] = [None] * self.num_mixtures  # nopep8
         for n in range(self.num_mixtures):
             num_densities = self.read_u32()
             dns_idx = []


### PR DESCRIPTION
This is especially useful when reading caches that only have one value per element, for instance caches from `EnergyJob`s.