### PR TITLE
Adding another possibility to provide the num_words in order to compute this dynamically

### DIFF
--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -159,7 +159,7 @@ class VocabularyFromTextJob(Job):
     Extract vocabulary from given text files based on frequency.
     """
 
-    def __init__(self, file_paths: List[tk.Path], num_words: int = 1_000_000):
+    def __init__(self, file_paths: List[tk.Path], num_words: Union[int, tk.Variable] = 1_000_000):
         """
         :param file_paths: paths to the text files
         :param num_words: expected size of the vocabulary
@@ -185,12 +185,14 @@ class VocabularyFromTextJob(Job):
                     words = line.strip().split()
                     counter.update(words)
 
-        cutoff = min(self.num_words, len(counter))
+        num_words = self.num_words if isinstance(self.num_words, int) else self.num_words.get()
+
+        cutoff = min(num_words, len(counter))
 
         with open(self.out_vocabulary, "w") as vocabulary, open(
             self.out_vocabulary_with_counts, "w"
         ) as vocabulary_with_counts:
-            for (word, count) in counter.most_common(cutoff):
+            for word, count in counter.most_common(cutoff):
                 vocabulary.write(f"{word}\n")
                 vocabulary_with_counts.write(f"{word} {count}\n")
 

--- a/lm/vocabulary.py
+++ b/lm/vocabulary.py
@@ -185,7 +185,7 @@ class VocabularyFromTextJob(Job):
                     words = line.strip().split()
                     counter.update(words)
 
-        num_words = self.num_words if isinstance(self.num_words, int) else self.num_words.get()
+        num_words = self.num_words.get() if isinstance(self.num_words, tk.Variable) else self.num_words
 
         cutoff = min(num_words, len(counter))
 


### PR DESCRIPTION
In the context of creating the vocab using all the in-domain data plus the remaining words from other text sources, this job now can receive also a variable that comes from subtracting the in-domain words to the num_words originally specified.

i.e:

```

def get_vocab_prior_id(experiment_name: str, corpus_files: Dict[str, tk.Path], vocab_size: int, *kwargs) -> tk.Path:
    
    vocab_files_id = []
    corpus_files_od = {}
    for corpus_name, corpus_file in corpus_files.items():
        if "DOMAIN_TAG" in corpus_name:
            vocab_files_id.append(corpus_file)
        else:
            corpus_files_od[corpus_name] = corpus_file
    vocabulary_job = VocabularyFromTextJob(file_paths=vocab_files_id, num_words=vocab_size)
    voc_size_id = ComputeTextCorpusStatisticsJob(vocabulary_job.out_vocabulary).out_num_lines
    vocab_size_od = vocab_size - voc_size_id
    vocab_ood = get_vocab_combine_all(experiment_name, corpus_files_od, vocab_size_od)
    vocab_ood_id = ConcatenateJob([vocab_ood, vocabulary_job.out_vocabulary], zip_out=False, out_name="vocab").out
    return vocab_ood_id`
```