### PR TITLE
Update lib.lexicon.Lexicon: don't add phoneme-inventory element when lexicon doesn't have phonemes

### DIFF
--- a/lib/lexicon.py
+++ b/lib/lexicon.py
@@ -161,13 +161,14 @@ class Lexicon:
         """
         root = ET.Element("lexicon")
 
-        pi = ET.SubElement(root, "phoneme-inventory")
-        for symbol, variation in self.phonemes.items():
-            p = ET.SubElement(pi, "phoneme")
-            s = ET.SubElement(p, "symbol")
-            s.text = symbol
-            v = ET.SubElement(p, "variation")
-            v.text = variation
+        if self.phonemes:
+            pi = ET.SubElement(root, "phoneme-inventory")
+            for symbol, variation in self.phonemes.items():
+                p = ET.SubElement(pi, "phoneme")
+                s = ET.SubElement(p, "symbol")
+                s.text = symbol
+                v = ET.SubElement(p, "variation")
+                v.text = variation
 
         for l in self.lemmata:
             root.append(l.to_xml())


### PR DESCRIPTION
This change might break other setups, so it's fine if you don't want to merge this.