### PR TITLE
Fix FairseqHydraPretrainJob for better start_checkpoint behavior

### DIFF
--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -241,7 +241,7 @@ class FairseqHydraTrainingJob(Job):
         }
         res.update(FairseqHydraConfig(config_dict, post_config_dict))
         return res
-    
+
     def _fairseq_prepare_checkpoint(self, start_checkpoint):
         # rename the start checkpoint to checkpoint_last.pt if it is not None and checkpoint_last.pt does not exist
         if start_checkpoint is None:
@@ -251,13 +251,9 @@ class FairseqHydraTrainingJob(Job):
             raise FileNotFoundError(f"Start checkpoint {start_checkpoint} does not exist")
         if not os.path.exists(os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")):
             print(f"Linking {start_checkpoint} to {self.out_checkpoint_dir.get_path()}")
+            os.symlink(start_checkpoint, os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt"))
             os.symlink(
-                start_checkpoint,
-                os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")
-            )
-            os.symlink(
-                start_checkpoint,
-                os.path.join(self.out_checkpoint_dir.get_path(), os.path.basename(start_checkpoint))
+                start_checkpoint, os.path.join(self.out_checkpoint_dir.get_path(), os.path.basename(start_checkpoint))
             )
 
     def create_files(self):

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -177,19 +177,7 @@ class FairseqHydraTrainingJob(Job):
         kwargs = locals()
         del kwargs["self"]
 
-        # check for start checkpoint
-        #if (
-        #    fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file", None) is not None
-        #    and fairseq_hydra_config.data["checkpoint"]["restore_file"] != "checkpoint_last.pt"
-        #    and os.path.exists(os.path.join(self.output_path("checkpoints", directory=True), "checkpoint_last.pt"))
-        #):
-        #    # start_checkpoint provided but checkpoint_last.pt exists: start_checkpoint will be ignored
-        #    print(
-        #        "Warning: start_checkpoint will be ignored as checkpoint_last.pt exists in output directory"
-        #    )
-        #    fairseq_hydra_config.data["checkpoint"]["restore_file"] = "checkpoint_last.pt"
-
-        
+        # save start checkpoint and rename to checkpoint_latest
         self.start_checkpoint = None
         if fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file") is not None:
             self.start_checkpoint = fairseq_hydra_config.data["checkpoint"]["restore_file"]

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -178,10 +178,7 @@ class FairseqHydraTrainingJob(Job):
         del kwargs["self"]
 
         # save start checkpoint and rename to checkpoint_latest
-        self.start_checkpoint = None
-        if fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file") is not None:
-            self.start_checkpoint = fairseq_hydra_config.data["checkpoint"]["restore_file"]
-            fairseq_hydra_config.data["checkpoint"]["restore_file"] = "checkpoint_last.pt"
+        self.start_checkpoint = fairseq_hydra_config.data.get("checkpoint", {}).pop("restore_file")
 
         self.command_line_args = command_line_args or []
         stored_epochs = list(range(save_interval, max_epoch, save_interval)) + [max_epoch]

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -260,10 +260,12 @@ class FairseqHydraTrainingJob(Job):
     def _fairseq_prepare_checkpoint(self, start_checkpoint):
         # rename the start checkpoint to checkpoint_last.pt if it is not None and checkpoint_last.pt does not exist
         if start_checkpoint is None:
+            print("No start checkpoint provided")
             return
         if not os.path.exists(start_checkpoint):
             raise FileNotFoundError(f"Start checkpoint {start_checkpoint} does not exist")
         if not os.path.exists(os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")):
+            print(f"Linking {start_checkpoint} to {self.out_checkpoint_dir.get_path()}")
             os.link(
                 start_checkpoint,
                 os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -177,7 +177,23 @@ class FairseqHydraTrainingJob(Job):
         kwargs = locals()
         del kwargs["self"]
 
+<<<<<<< HEAD
         # save start checkpoint and rename to checkpoint_latest
+=======
+        # check for start checkpoint
+        #if (
+        #    fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file", None) is not None
+        #    and fairseq_hydra_config.data["checkpoint"]["restore_file"] != "checkpoint_last.pt"
+        #    and os.path.exists(os.path.join(self.output_path("checkpoints", directory=True), "checkpoint_last.pt"))
+        #):
+        #    # start_checkpoint provided but checkpoint_last.pt exists: start_checkpoint will be ignored
+        #    print(
+        #        "Warning: start_checkpoint will be ignored as checkpoint_last.pt exists in output directory"
+        #    )
+        #    fairseq_hydra_config.data["checkpoint"]["restore_file"] = "checkpoint_last.pt"
+
+        
+>>>>>>> c5d0a9f (fix when using restore_file)
         self.start_checkpoint = None
         if fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file") is not None:
             self.start_checkpoint = fairseq_hydra_config.data["checkpoint"]["restore_file"]

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -177,23 +177,7 @@ class FairseqHydraTrainingJob(Job):
         kwargs = locals()
         del kwargs["self"]
 
-<<<<<<< HEAD
         # save start checkpoint and rename to checkpoint_latest
-=======
-        # check for start checkpoint
-        #if (
-        #    fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file", None) is not None
-        #    and fairseq_hydra_config.data["checkpoint"]["restore_file"] != "checkpoint_last.pt"
-        #    and os.path.exists(os.path.join(self.output_path("checkpoints", directory=True), "checkpoint_last.pt"))
-        #):
-        #    # start_checkpoint provided but checkpoint_last.pt exists: start_checkpoint will be ignored
-        #    print(
-        #        "Warning: start_checkpoint will be ignored as checkpoint_last.pt exists in output directory"
-        #    )
-        #    fairseq_hydra_config.data["checkpoint"]["restore_file"] = "checkpoint_last.pt"
-
-        
->>>>>>> c5d0a9f (fix when using restore_file)
         self.start_checkpoint = None
         if fairseq_hydra_config.data.get("checkpoint", {}).get("restore_file") is not None:
             self.start_checkpoint = fairseq_hydra_config.data["checkpoint"]["restore_file"]

--- a/fairseq/training.py
+++ b/fairseq/training.py
@@ -254,11 +254,11 @@ class FairseqHydraTrainingJob(Job):
             raise FileNotFoundError(f"Start checkpoint {start_checkpoint} does not exist")
         if not os.path.exists(os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")):
             print(f"Linking {start_checkpoint} to {self.out_checkpoint_dir.get_path()}")
-            os.link(
+            os.symlink(
                 start_checkpoint,
                 os.path.join(self.out_checkpoint_dir.get_path(), "checkpoint_last.pt")
             )
-            os.link(
+            os.symlink(
                 start_checkpoint,
                 os.path.join(self.out_checkpoint_dir.get_path(), os.path.basename(start_checkpoint))
             )


### PR DESCRIPTION
Currently, when `fairseq_hydra_config["checkpoint"]["restore_file"]` is given as a parameter for the pretraining, this makes resuming jobs much more difficult since it will always restart from the given file - even though the model might have been trained for several more epochs already. Since changing the `restore_file` parameter to the new checkpoint  would change the job parameter again, the job would also not be able continue training again.

I therefore propose to handle the `"restore_file"` parameter in the job individually and not leaving it to fairseq. The idea is to save the given `"restore_file"` as a job attribute to later move it to `"output/checkpoints/checkpoint_last.pt"` if the latter does not exist yet, which is also the default parameter inside fairseq. That way, when training has been already done for several epochs, the job can still continue from `checkpoint_last.pt`, and use the given checkpoint if the training hasn't already ran earlier.