### PR TITLE
Fix DumpAlignmentJob flow

### DIFF
--- a/mm/flow.py
+++ b/mm/flow.py
@@ -95,7 +95,7 @@ def dump_alignment_flow(feature_net, original_alignment, new_alignment):
     assert "features" in feature_net.get_output_ports()
     net = FlowNetwork()
     net.add_output("alignments")
-    net.add_param("orthography")
+    net.add_param(["id", "orthography", "TASK"])
 
     mapping = net.add_net(feature_net)
     net.interconnect_inputs(feature_net, mapping)


### PR DESCRIPTION
The flow needed the parameters 'id' and 'TASK'.

Extract of the `dump.flow` used by the job:
```
  <node filter="generic-cache" id="$(id)" name="alignment-cache" path=".../alignment.cache.$(TASK)"/>
[...]
  <node file="alignment.cache.$(TASK)" filter="speech-alignment-dump" id="$(id)" name="dumper"/>
```