### PR TITLE
Fix compute ppl job

### DIFF
--- a/lm/perplexity.py
+++ b/lm/perplexity.py
@@ -1,4 +1,4 @@
-__all__ = ["ComputePerplexityJob"]
+__all__ = ["ComputePerplexityJob", "ComputePerplexityJobV2"]
 
 from sisyphus import *
 

--- a/lm/perplexity.py
+++ b/lm/perplexity.py
@@ -135,7 +135,7 @@ class ComputePerplexityJob(rasr.RasrCommand, Job):
         return config, post_config
 
 
-class ComputePerplexityJobV2(ComputePerplexityJobV2):
+class ComputePerplexityJobV2(ComputePerplexityJob):
     """
     Update of ComputePerplexityJob with a custom hash function that only hashes relevant inputs.
     Previous version will change hash even if unrelated components in the CommonRasrParameters object

--- a/lm/perplexity.py
+++ b/lm/perplexity.py
@@ -133,3 +133,16 @@ class ComputePerplexityJob(rasr.RasrCommand, Job):
         post_config._update(extra_post_config)
 
         return config, post_config
+
+
+class ComputePerplexityJobV2(ComputePerplexityJobV2):
+    """
+    Update of ComputePerplexityJob with a custom hash function that only hashes relevant inputs.
+    Previous version will change hash even if unrelated components in the CommonRasrParameters object
+    change their value, e.g. the acoustic-model.
+    """
+
+    @classmethod
+    def hash(cls, kwargs):
+        config, post_config, num_images = cls.create_config(**kwargs)
+        return super().hash({"config": config, "exe": kwargs["crp"].lm_util_exe})

--- a/lm/perplexity.py
+++ b/lm/perplexity.py
@@ -144,5 +144,5 @@ class ComputePerplexityJobV2(ComputePerplexityJob):
 
     @classmethod
     def hash(cls, kwargs):
-        config, post_config, num_images = cls.create_config(**kwargs)
+        config, post_config = cls.create_config(**kwargs)
         return super().hash({"config": config, "exe": kwargs["crp"].lm_util_exe})


### PR DESCRIPTION
Currently any change to the crp object will change the hash of ComputePerplexityJob. Even changes to the acoustic model for example. Typically RASR jobs implement their own hash function to hash the generated config, not the input crp. This was overlooked for the ComputePerplexityJob. To avoid breaking hashes I add a new version with the fixed behavior.