### PR TITLE
Fix newline in Bliss corpus orth

### DIFF
--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -123,7 +123,7 @@ class CorpusParser(sax.handler.ContentHandler):
             # writing, thus we remove multiple spaces and newlines
             text = self.chars.strip()
             text = re.sub(" +", " ", text)
-            text = re.sub("\n", "", text)
+            text = re.sub("\n", " ", text)
             e.orth = text
         elif isinstance(e, Speaker) and name != "speaker-description":
             # we allow all sorts of elements within a speaker description


### PR DESCRIPTION
The actual functionality of the code seems ambiguous with respect to the explanatory comment some lines above.

In order to keep the information from the writing, the newline should be substituted by a space, and not by an empty string. Example:

```
HELLO
WORLD
```

Current functionality: `HELLOWORLD`.

My proposal is consistent with the human way of reading: `HELLO WORLD`.