### PR TITLE
`BlissToPcmHDFJob`: change `round_factor` typing from `int` to `float`

### DIFF
--- a/returnn/hdf.py
+++ b/returnn/hdf.py
@@ -229,7 +229,7 @@ class BlissToPcmHDFJob(Job):
     __sis_hash_exclude__ = {
         "multi_channel_strategy": BaseStrategy(),
         "rounding": RoundingScheme.start_and_duration,
-        "round_factor": 1,
+        "round_factor": 1.0,
     }
 
     def __init__(
@@ -240,7 +240,7 @@ class BlissToPcmHDFJob(Job):
         multi_channel_strategy: BaseStrategy = BaseStrategy(),
         returnn_root: Optional[tk.Path] = None,
         rounding: RoundingScheme = RoundingScheme.start_and_duration,
-        round_factor: int = 1,
+        round_factor: float = 1.0,
     ):
         """
 


### PR DESCRIPTION
Right now the typing of `round_factor` in `BlissToPcmHDFJob` implies that the original sampling rate is a divisor of the new sampling rate. For instance, 8kHz -> 16kHz conversion is supported, but not 16kHz -> 44.1kHz.

Moreover, downsampling would not be supported either, since 16kHz -> 8kHz results in `round_factor = 0.5`.

This PR aims to fix this issue by simply treating `round_factor` as a floating point number. I haven't seen anything in the code that could interfere with this change. Do you see anything against this change? 