### PR TITLE
SpellingConversionJob: clean lexicon if multiple mappings have been applied

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -506,9 +506,7 @@ class SpellingConversionJob(Job):
             elif source_lemma:
                 # Remove target orth if already present at a later position
                 # and insert it at the first position again
-                for orth in source_lemma.orth.copy():
-                    if orth == target_orth:
-                        source_lemma.orth.remove(orth)
+                source_lemma.orth = [orth for orth in source_lemma.orth if orth != target_orth]
                 source_lemma.orth.insert(0, target_orth)
                 if not source_lemma.synt:
                     source_lemma.synt = source_orth.split()

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -506,7 +506,7 @@ class SpellingConversionJob(Job):
             elif source_lemma:
                 # Remove target orth if already present at a later position
                 # and insert it at the first position again
-                for orth in source_lemma.orth:
+                for orth in source_lemma.orth.copy():
                     if orth == target_orth:
                         source_lemma.orth.remove(orth)
                 source_lemma.orth.insert(0, target_orth)

--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple, Union
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
-from sisyphus import *
+from sisyphus import tk, Task, Job, setup_path
 
 Path = setup_path(__package__)
 
@@ -504,9 +504,17 @@ class SpellingConversionJob(Job):
                     lex.lemmata.insert(target_position - 1, copy_target_lemma)
                 logging.info(self._lemma_to_str(target_lemma, "final lemma"))
             elif source_lemma:
+                # Remove target orth if already present at a later position
+                # and insert it at the first position again
+                for orth in source_lemma.orth:
+                    if orth == target_orth:
+                        source_lemma.orth.remove(orth)
                 source_lemma.orth.insert(0, target_orth)
                 if not source_lemma.synt:
                     source_lemma.synt = source_orth.split()
+                # Remove syntactic token mapping if equal to the target_orth
+                if source_lemma.synt == target_orth.split():
+                    source_lemma.synt = None
                 logging.info(self._lemma_to_str(source_lemma, "final lemma"))
             logging.info("-" * 60)
 


### PR DESCRIPTION
For our **EN_US** lexicon we used this job to map all **UK** spellings to **US** spellings:
For example:
```
<lemma>
<orth>backpedaled</orth>
<orth>backpedalled</orth>
<phon>b æ k p ɛ d ə l d</phon>
<synt>
<tok>backpedalled</tok>
</synt>
</lemma>
```
so far so good, but now for the **EN_GB** lexicon we use the **EN_US** lexicon and map it all to **UK** spelling again, which resulted in this redundant, a bit ugly, but not incorrect lemma:
```
<lemma>
<orth>backpedalled</orth>
<orth>backpedaled</orth>
<orth>backpedalled</orth>
<phon>b æ k p ɛ d ə l d</phon>
<synt>
<tok>backpedalled</tok>
</synt>
</lemma>
```
with my code fixes here the final lemma looks like this, which is much nicer:
```
<lemma>
<orth>backpedalled</orth>
<orth>backpedaled</orth>
<phon>b æ k p ɛ d ə l d</phon>
</lemma>
```

I am very sure I am the first person who ever encountered that :-) 