### PR TITLE
Make check for `dyn_size_ext` explicit

### DIFF
--- a/returnn/compile.py
+++ b/returnn/compile.py
@@ -308,6 +308,6 @@ class TorchOnnxExportJob(Job):
             tensor = Tensor(name=name, **opts)
             for i, dim in enumerate(tensor.dims):
                 # We need seq lengths if there is a dyn size which is not a scalar.
-                if dim.dyn_size_ext and dim.dyn_size_ext.dims:
+                if dim.dyn_size_ext is not None and dim.dyn_size_ext.dims:
                     names.append(f"{name}:size{i}")
         return names


### PR DESCRIPTION
After https://github.com/rwth-i6/returnn/issues/1680 (and behavior version 22) tensors are no longer allowed in boolean contexts. Therefore checks for whether `dyn_size_ext` exists must be done more explicitly by checking for `dyn_size_ext is not None`.