### PR TITLE
Add `reformat_orth` parameter to `Corpus.load()`

### DIFF
--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -129,12 +129,13 @@ class CorpusParser(sax.handler.ContentHandler):
 
         if name in {"orth", "left-context-orth", "right-context-orth"}:
             assert isinstance(e, Segment)
+            text = self.chars
             if self.pretty_format_orth:
                 # we do some processing of the text that goes into the orth tag to get a nicer formating,
                 # some corpora may have multiline content in the orth tag,
                 # but to keep it that way might not be consistent with the indentation during writing,
                 # thus we remove multiple spaces and newlines
-                text = self.chars.strip()
+                text = text.strip()
                 text = re.sub(" +", " ", text)
                 text = re.sub("\n", "", text)
             setattr(e, name.replace("-", "_"), text)

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -129,13 +129,14 @@ class CorpusParser(sax.handler.ContentHandler):
 
         if name in {"orth", "left-context-orth", "right-context-orth"}:
             assert isinstance(e, Segment)
-            text = self.chars
+            # Minimum formatting (strip) to prevent spaces from accumulating to the left/right of the orth
+            # due to print("<orth> {orth} </orth>").
+            text = self.chars.strip()
             if self.reformat_orth:
                 # we do some processing of the text that goes into the orth tag to get a nicer-looking formating,
                 # some corpora may have multiline content in the orth tag,
                 # but to keep it that way might not be consistent with the indentation during writing,
                 # thus we remove multiple spaces and newlines
-                text = text.strip()
                 text = re.sub(" +", " ", text)
                 text = re.sub("\n", "", text)
             setattr(e, name.replace("-", "_"), text)

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -279,7 +279,7 @@ class Corpus(NamedEntity, CorpusSection):
         for sc in self.subcorpora:
             sc.filter_segments(filter_function)
 
-    def load(self, path: str, pretty_format_orth: bool = False):
+    def load(self, path: str, pretty_format_orth: bool = True):
         """
         :param path: corpus .xml or .xml.gz
         :param pretty_format_orth: Whether to do some processing of the text


### PR DESCRIPTION
Counter-proposal to https://github.com/rwth-i6/i6_core/pull/560.

Allow the user to set whether the "nicer Bliss corpus formatting" should be applied or not. By default it's applied so that the default behavior is not overridden. I still believe that the user should have the capability to control this behavior, hence the reason for this PR.

Many less reviewers this time since it's a much less breaking change :)