### PR TITLE
add __repr__ for corpus objects

### DIFF
--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -463,7 +463,7 @@ class Segment(NamedEntity):
             out.write("</segment>\n")
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.fullname()}:{self.start:.02f}-{self.end:.02f})"
+        return f"<{self.__class__.__name__} {self.fullname()} {self.start:.02f}-{self.end:.02f})>"
 
 
 class Speaker(NamedEntity):

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -26,7 +26,10 @@ class NamedEntity:
         self.name: Optional[str] = None
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.fullname()})"
+        if self.name is None:
+            return f"<{self.__class__.__name__}>"
+        else:
+            return f"<{self.__class__.__name__} {self.name}>"
 
 
 class CorpusSection:
@@ -344,6 +347,9 @@ class Corpus(NamedEntity, CorpusSection):
         """
         return {rec.fullname(): rec for rec in self.all_recordings()}
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.fullname()}>"
+
 
 class Recording(NamedEntity, CorpusSection):
     def __init__(self):
@@ -386,6 +392,9 @@ class Recording(NamedEntity, CorpusSection):
         :return: Mapping from segment fullnames to actual segments.
         """
         return {seg.fullname(): seg for seg in self.segments}
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.fullname()}>"
 
 
 class Segment(NamedEntity):

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -25,6 +25,9 @@ class NamedEntity:
         super().__init__()
         self.name: Optional[str] = None
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.fullname()})"
+
 
 class CorpusSection:
     def __init__(self):
@@ -458,6 +461,9 @@ class Segment(NamedEntity):
             out.write("%s</segment>\n" % indentation)
         else:
             out.write("</segment>\n")
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.fullname()}:{self.start:.02f}-{self.end:.02f})"
 
 
 class Speaker(NamedEntity):


### PR DESCRIPTION
Recently, I was playing around with segmentations and I found it useful to have a better representation of the corpus objects (mainly `Segment`, but also `Recording`) when printing them for testing. It's only a small change, but maybe someone else could also like it in the future.