### PR TITLE
Add `reformat_orth` to `MapRecordingsJob`

### DIFF
--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -640,13 +640,27 @@ class MapRecordingsJob(Job):
     Applies a function to all recordings of a given corpus.
     """
 
-    def __init__(self, bliss_corpus: tk.Path, recording_callable: Callable[[corpus.Recording], corpus.Recording]):
+    __sis_hash_exclude__ = {"reformat_orth": True}
+
+    def __init__(
+        self,
+        bliss_corpus: tk.Path,
+        recording_callable: Callable[[corpus.Recording], corpus.Recording],
+        reformat_orth: bool = True,
+    ):
         """
         :param bliss_corpus: Corpus for which to sort the segments.
         :param recording_callable: Callable to modify a given recording. Returns the modified recording.
+        :param reformat_orth: Whether to do some processing of the text
+            that goes into the orth tag to get a nicer-looking formating.
+            If `True`, removes multiline content in the orth tag, leading/trailing spaces,
+            and multiple spaces inside the text.
+
+            Defaults to `True` (initial behavior of :class:`Corpus`).
         """
         self.bliss_corpus = bliss_corpus
         self.recording_callable = recording_callable
+        self.reformat_orth = reformat_orth
 
         self.out_bliss_corpus = self.output_path("out.xml.gz")
 
@@ -664,7 +678,7 @@ class MapRecordingsJob(Job):
 
     def run(self):
         c = corpus.Corpus()
-        c.load(self.bliss_corpus.get_path())
+        c.load(self.bliss_corpus.get_path(), reformat_orth=self.reformat_orth)
 
         self.map_recordings(c, self.recording_callable)
         for sc in c.subcorpora:

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -646,6 +646,7 @@ class MapRecordingsJob(Job):
         self,
         bliss_corpus: tk.Path,
         recording_callable: Callable[[corpus.Recording], corpus.Recording],
+        *,
         corpus_load_reformat_orth: bool = True,
     ):
         """

--- a/corpus/transform.py
+++ b/corpus/transform.py
@@ -640,27 +640,25 @@ class MapRecordingsJob(Job):
     Applies a function to all recordings of a given corpus.
     """
 
-    __sis_hash_exclude__ = {"reformat_orth": True}
+    __sis_hash_exclude__ = {"corpus_load_reformat_orth": True}
 
     def __init__(
         self,
         bliss_corpus: tk.Path,
         recording_callable: Callable[[corpus.Recording], corpus.Recording],
-        reformat_orth: bool = True,
+        corpus_load_reformat_orth: bool = True,
     ):
         """
         :param bliss_corpus: Corpus for which to sort the segments.
         :param recording_callable: Callable to modify a given recording. Returns the modified recording.
-        :param reformat_orth: Whether to do some processing of the text
-            that goes into the orth tag to get a nicer-looking formating.
-            If `True`, removes multiline content in the orth tag, leading/trailing spaces,
+        :param reformat_orth: If `True`, the corpus loading will remove newline characters
             and multiple spaces inside the text.
 
             Defaults to `True` (initial behavior of :class:`Corpus`).
         """
         self.bliss_corpus = bliss_corpus
         self.recording_callable = recording_callable
-        self.reformat_orth = reformat_orth
+        self.corpus_load_reformat_orth = corpus_load_reformat_orth
 
         self.out_bliss_corpus = self.output_path("out.xml.gz")
 
@@ -678,7 +676,7 @@ class MapRecordingsJob(Job):
 
     def run(self):
         c = corpus.Corpus()
-        c.load(self.bliss_corpus.get_path(), reformat_orth=self.reformat_orth)
+        c.load(self.bliss_corpus.get_path(), reformat_orth=self.corpus_load_reformat_orth)
 
         self.map_recordings(c, self.recording_callable)
         for sc in c.subcorpora:

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -54,8 +54,7 @@ class CorpusParser(sax.handler.ContentHandler):
         :param path: Path of the parent corpus (needed for include statements).
         :param reformat_orth: Whether to do some processing of the text
             that goes into the orth tag to get a nicer-looking formating.
-            If `True`, removes multiline content in the orth tag, leading/trailing spaces,
-            and multiple spaces inside the text.
+            If `True`, removes newline characters and multiple spaces inside the text.
 
             Defaults to `True` (initial behavior of :class:`Corpus`).
         """
@@ -292,8 +291,7 @@ class Corpus(NamedEntity, CorpusSection):
         :param path: corpus .xml or .xml.gz
         :param reformat_orth: Whether to do some processing of the text
             that goes into the orth tag to get a nicer-looking formating.
-            If `True`, removes multiline content in the orth tag, leading/trailing spaces,
-            and multiple spaces inside the text.
+            If `True`, removes newline characters and multiple spaces inside the text.
 
             Defaults to `True` (initial behavior of :class:`Corpus`).
         """


### PR DESCRIPTION
I'd need to access `reformat_orth` when loading a corpus via `MapRecordingsJob`.

I hope I don't need it anymore, but I can't guarantee that we'll need it in the future. Maybe we can use this PR as a base for future courses of action when developing new jobs, or needing the `reformat_orth` in old jobs.