### PR TITLE
Fix an issue in ConcatenateJob with command line too long if too many files

### DIFF
--- a/text/processing.py
+++ b/text/processing.py
@@ -141,9 +141,7 @@ class ConcatenateJob(Job):
         assert isinstance(text_files, list)
 
         for input_file in text_files:
-            assert isinstance(input_file, Path) or isinstance(
-                input_file, str
-            ), "input to Concatenate is not a valid path"
+            assert isinstance(input_file, (Path, str)), "input to Concatenate is not a valid path"
 
         self.text_files = text_files
         self.zip_out = zip_out
@@ -168,7 +166,7 @@ class ConcatenateJob(Job):
 
         with util.uopen(self.out, "wb") as out_file:
             for f in self.f_list:
-                print(f)
+                logging.info(f)
                 with util.uopen(f, "rb") as in_file:
                     shutil.copyfileobj(in_file, out_file)
 

--- a/text/processing.py
+++ b/text/processing.py
@@ -159,13 +159,13 @@ class ConcatenateJob(Job):
         yield Task("run", rqmt={"mem": 3, "time": 3})
 
     def run(self):
-        self.f_list = [
+        f_list = [
             gs.file_caching(text_file) if isinstance(text_file, str) else text_file.get_cached_path()
             for text_file in self.text_files
         ]
 
         with util.uopen(self.out, "wb") as out_file:
-            for f in self.f_list:
+            for f in f_list:
                 logging.info(f)
                 with util.uopen(f, "rb") as in_file:
                     shutil.copyfileobj(in_file, out_file)
@@ -368,8 +368,8 @@ class SplitTextFileJob(Job):
             logging.info("Split lines")
             split_cmd = [
                 "split",
-                "-l",
-                str(self.num_lines_per_split),
+                "-c",
+                f"l/{str(self.num_lines_per_split)}",
                 "--suffix-length=4",
                 "--numeric-suffixes=1",
                 "--additional-suffix=.txt",

--- a/text/processing.py
+++ b/text/processing.py
@@ -368,8 +368,8 @@ class SplitTextFileJob(Job):
             logging.info("Split lines")
             split_cmd = [
                 "split",
-                "-c",
-                f"l/{str(self.num_lines_per_split)}",
+                "-l",
+                str(self.num_lines_per_split),
                 "--suffix-length=4",
                 "--numeric-suffixes=1",
                 "--additional-suffix=.txt",


### PR DESCRIPTION
if there is too many files ("too many" depends on the lenght of the paths and name itself), the original command fails as there is build-in limit on the length of program arguments in bas (IIRC around 13k bytes).
This change fixes this issue.