### PR TITLE
Add `CallImport`

### DIFF
--- a/serialization/base.py
+++ b/serialization/base.py
@@ -220,7 +220,9 @@ class PartialImport(Import):
 
 class CallImport(PartialImport):
     """
-    Like PartialImport, but issues a full, not just a partial call to the imported callable.
+    Imports some function/class and calls it with given args.
+
+    See also :class:`PartialImport` to get a partial function/class.
     """
 
     TEMPLATE = textwrap.dedent(


### PR DESCRIPTION
Like `PartialImport`, but actually calls through the callable. This is helpful for when you are trying to import callable classes that you wish to initialize during the import process. When you do this through `PartialImport`, the `PartialImport` will only fix the arguments, but not actually call your classes' `__init__`.

E.g. this simplifies importing https://github.com/rwth-i6/returnn/blob/0baf1d99bdc1afbd90aeaa080642098c2aa13f52/returnn/datasets/postprocessing.py#L396-L402