### PR TITLE
Recording alignment confidence filtering job

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -225,11 +225,13 @@ class FilterSegmentsByRecordingAlignmentConfidenceJob(Job):
         absolute_threshold: Optional[float] = None,
     ):
         """
-        :param alignment_logs: alignment_job.out_log_file; task_id -> log_file
-        :param percentile: percent of alignment segments to keep. should be in (0,100]. for :func:`np.percentile`
-        :param crp: used to set the number of output segments. if none, number of alignment log files is used instead.
-        :param plot: plot the distribution of alignment scores
-        :param absolute_threshold: alignments with score above this number are discarded
+        :param alignment_logs: Mapping of task ID to log file (`alignment_job.out_log_file`).
+        :param percentile: Percent of alignment segments to keep, used in :func:`np.percentile`.
+            The higher percentile of alignment scores will be discarded.
+        :param crp: Used to set the number of output segments. If `None`, number of alignment log files is used instead.
+        :param plot: Plot the distribution of recording alignment scores with respect to the recordings.
+        :param absolute_threshold: If the recording has an average alignment score above this number,
+            all recordings are discarded.
         """
         self.alignment_logs = alignment_logs  # alignment_job.log_file
         self.percentile = percentile

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -247,8 +247,10 @@ class FilterSegmentsByRecordingAlignmentConfidenceJob(Job):
         if plot:
             self.out_plot_avg = self.output_path("score.png")
 
+        self.rqmt = {"cpu": 1, "mem": 2.0, "time": 1.0}
+
     def tasks(self):
-        yield Task("run", resume="run", mini_task=True)
+        yield Task("run", resume="run", rqmt=self.rqmt)
 
     def run(self):
         # Mapping from recording name to list of (segments + average segment alignment confidence).

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -8,12 +8,13 @@ __all__ = [
     "FilterCorpusBySegmentDurationJob",
 ]
 
+from collections import defaultdict
 import gzip
 import logging
 import numpy as np
 import re
 import xml.etree.cElementTree as ET
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from i6_core import rasr
 from i6_core.lib import corpus


### PR DESCRIPTION
We have a filtering job for alignments whose average confidence score is greater than a threshold specified by the user.

This PR proposes the `FilterSegmentsByRecordingAlignmentConfidenceJob`, which:
1. Obtains the average confidence score of each recording (simply defined as the average of the segment alignment scores that compose each recording).
2. Filters out a recording (that is, filters out all segments from the recording) if the recording confidence score is greater than the threshold specified by the user.