### PR TITLE
`ComputeTimeStampErrorJob`: allow multiple caches as input, add output file with individual TSEs per segment pair

### DIFF
--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -13,8 +13,8 @@ import math
 import os
 import shutil
 import statistics
+from typing import Callable, Counter, Dict, List, Optional, Tuple, Union
 import xml.etree.ElementTree as ET
-from typing import Callable, Counter, List, Optional, Tuple, Union
 
 from sisyphus import *
 

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -759,11 +759,7 @@ class ComputeTimeStampErrorJob(Job):
             for ref_seq_tag, (hyp_seq_tag, avg_tse) in sorted(
                 tse_dict.items(), key=lambda k_v: k_v[1][1], reverse=True
             ):
-                if ref_seq_tag == hyp_seq_tag:
-                    # No need to be redundant in the output format.
-                    f.write(f"{ref_seq_tag}\t{avg_tse}\n")
-                else:
-                    f.write(f"{ref_seq_tag}\t{hyp_seq_tag}\t{avg_tse}\n")
+                f.write(f"{ref_seq_tag}\t{hyp_seq_tag}\t{avg_tse}\n")
 
     def plot(self):
         for descr, dict_file, plot_file in [

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -589,6 +589,7 @@ class ComputeTimeStampErrorJob(Job):
         self.out_plot_word_end_frame_differences = self.output_path("end_frame_differences.png")
         self.out_boundary_frame_differences = self.output_var("boundary_frame_differences")
         self.out_plot_boundary_frame_differences = self.output_path("boundary_frame_differences.png")
+        self.out_highest_tse_differences_file = self.output_path("highest_tse_differences.txt")
 
         self.rqmt = None
 
@@ -754,6 +755,15 @@ class ComputeTimeStampErrorJob(Job):
         self.out_word_end_frame_differences.set({key: end_differences[key] for key in sorted(end_differences.keys())})
         self.out_boundary_frame_differences.set({key: differences[key] for key in sorted(differences.keys())})
         self.out_tse_frames.set(statistics.mean(abs(diff) for diff in differences.elements()))
+        with util.uopen(self.out_highest_tse_differences_file.get_path(), "wt") as f:
+            for ref_seq_tag, (hyp_seq_tag, avg_tse) in sorted(
+                tse_dict.items(), key=lambda k_v: k_v[1][1], reverse=True
+            ):
+                if ref_seq_tag == hyp_seq_tag:
+                    # No need to be redundant in the output format.
+                    f.write(f"{ref_seq_tag}\t{avg_tse}\n")
+                else:
+                    f.write(f"{ref_seq_tag}\t{hyp_seq_tag}\t{avg_tse}\n")
 
     def plot(self):
         for descr, dict_file, plot_file in [

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -542,8 +542,8 @@ class ComputeTimeStampErrorJob(Job):
 
     def __init__(
         self,
-        hyp_alignment_cache: tk.Path,
-        ref_alignment_cache: tk.Path,
+        hyp_alignment_cache: Union[tk.Path, List[tk.Path]],
+        ref_alignment_cache: Union[tk.Path, List[tk.Path]],
         hyp_allophone_file: tk.Path,
         ref_allophone_file: tk.Path,
         hyp_silence_phone: str = "[SILENCE]",
@@ -565,12 +565,16 @@ class ComputeTimeStampErrorJob(Job):
         :param hyp_seq_tag_transform: Function that transforms seq tag in alignment cache such that it matches the seq tags in the reference
         :param remove_outlier_limit: If set, boundary differences greater than this frame limit are discarded from computation
         """
-        self.hyp_alignment_cache = hyp_alignment_cache
+        self.hyp_alignment_cache = (
+            hyp_alignment_cache if isinstance(hyp_alignment_cache, List) else [hyp_alignment_cache]
+        )
         self.hyp_allophone_file = hyp_allophone_file
         self.hyp_silence_phone = hyp_silence_phone
         self.hyp_upsample_factor = hyp_upsample_factor
 
-        self.ref_alignment_cache = ref_alignment_cache
+        self.ref_alignment_cache = (
+            ref_alignment_cache if isinstance(ref_alignment_cache, List) else [ref_alignment_cache]
+        )
         self.ref_allophone_file = ref_allophone_file
         self.ref_silence_phone = ref_silence_phone
         self.ref_upsample_factor = ref_upsample_factor

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -589,7 +589,7 @@ class ComputeTimeStampErrorJob(Job):
         self.out_plot_word_end_frame_differences = self.output_path("end_frame_differences.png")
         self.out_boundary_frame_differences = self.output_var("boundary_frame_differences")
         self.out_plot_boundary_frame_differences = self.output_path("boundary_frame_differences.png")
-        self.out_highest_tse_differences_file = self.output_path("highest_tse_differences.txt")
+        self.out_tse_differences_file = self.output_path("tse_differences.txt")
 
         self.rqmt = None
 
@@ -755,7 +755,7 @@ class ComputeTimeStampErrorJob(Job):
         self.out_word_end_frame_differences.set({key: end_differences[key] for key in sorted(end_differences.keys())})
         self.out_boundary_frame_differences.set({key: differences[key] for key in sorted(differences.keys())})
         self.out_tse_frames.set(statistics.mean(abs(diff) for diff in differences.elements()))
-        with util.uopen(self.out_highest_tse_differences_file.get_path(), "wt") as f:
+        with util.uopen(self.out_tse_differences_file.get_path(), "wt") as f:
             for ref_seq_tag, (hyp_seq_tag, avg_tse) in sorted(
                 tse_dict.items(), key=lambda k_v: k_v[1][1], reverse=True
             ):

--- a/mm/alignment.py
+++ b/mm/alignment.py
@@ -565,14 +565,14 @@ class ComputeTimeStampErrorJob(Job):
         :param hyp_seq_tag_transform: Function that transforms seq tag in alignment cache such that it matches the seq tags in the reference
         :param remove_outlier_limit: If set, boundary differences greater than this frame limit are discarded from computation
         """
-        self.hyp_alignment_cache = (
+        self.hyp_alignment_caches = (
             hyp_alignment_cache if isinstance(hyp_alignment_cache, List) else [hyp_alignment_cache]
         )
         self.hyp_allophone_file = hyp_allophone_file
         self.hyp_silence_phone = hyp_silence_phone
         self.hyp_upsample_factor = hyp_upsample_factor
 
-        self.ref_alignment_cache = (
+        self.ref_alignment_caches = (
             ref_alignment_cache if isinstance(ref_alignment_cache, List) else [ref_alignment_cache]
         )
         self.ref_allophone_file = ref_allophone_file
@@ -647,7 +647,7 @@ class ComputeTimeStampErrorJob(Job):
         differences = Counter()
         tse_dict: Dict[str, Tuple[str, float]] = {}  # ref_seg_name: (hyp_seg_name, avg_tse)
 
-        for hyp_alignment_cache, ref_alignment_cache in zip(self.hyp_alignment_cache, self.ref_alignment_cache):
+        for hyp_alignment_cache, ref_alignment_cache in zip(self.hyp_alignment_caches, self.ref_alignment_caches):
             hyp_alignments = rasr_cache.open_file_archive(hyp_alignment_cache.get())
             hyp_alignments.setAllophones(self.hyp_allophone_file.get())
             if isinstance(hyp_alignments, rasr_cache.FileArchiveBundle):


### PR DESCRIPTION
1. Added option to input multiple caches instead of a single one. The TSE will be accumulated for each cache file provided.
2. Added output file for sorted (descending) list of highest TSEs.