### PR TITLE
Add job to write dict contents to a csv file

### DIFF
--- a/text/processing.py
+++ b/text/processing.py
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 from collections.abc import Iterable
 import tempfile
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from sisyphus import Job, Task, Path, global_settings as gs, toolkit as tk
 from sisyphus.delayed_ops import DelayedBase
@@ -340,7 +340,10 @@ class WriteToCsvFileJob(WriteToTextFileJob):
     __sis_hash_exclude__ = {}  # It was filled in the base class, but it's not needed anymore since this is a new job.
 
     def __init__(
-        self, content: Union[str, dict, Iterable, DelayedBase], out_name: str = "file.txt", delimiter: str = "\t"
+        self,
+        content: Dict[str, Union[str, List[str]]],
+        out_name: str = "file.txt",
+        delimiter: str = "\t",
     ):
         """
         :param content: input which will be written into a text file
@@ -361,8 +364,10 @@ class WriteToCsvFileJob(WriteToTextFileJob):
         content = util.instanciate_delayed(self.content)
         if isinstance(content, dict):
             for key, val in content.items():
-                csv_writer.writerow((key, val))
-
+                if isinstance(val, list):
+                    csv_writer.writerow((key, *val))
+                else:
+                    csv_writer.writerow((key, val))
         else:
             raise NotImplementedError("Content of unknown type different from (str, dict, Iterable).")
 

--- a/text/processing.py
+++ b/text/processing.py
@@ -336,6 +336,8 @@ class WriteToCsvFileJob(WriteToTextFileJob):
     This job only supports dictionaries as input type. Each key/value pair is written as `<key><delimiter><value>`.
     """
 
+    __sis_hash_exclude__ = {}  # It was filled in the base class, but it's not needed anymore since this is a new job.
+
     def __init__(
         self, content: Union[str, dict, Iterable, DelayedBase], out_name: str = "file.txt", delimiter: str = "\t"
     ):

--- a/text/processing.py
+++ b/text/processing.py
@@ -5,6 +5,7 @@ __all__ = [
     "TailJob",
     "SetDifferenceJob",
     "WriteToTextFileJob",
+    "WriteToCsvFileJob",
     "SplitTextFileJob",
 ]
 

--- a/text/processing.py
+++ b/text/processing.py
@@ -342,6 +342,7 @@ class WriteToCsvFileJob(WriteToTextFileJob):
     def __init__(
         self,
         content: Dict[str, Union[str, List[str]]],
+        *,
         out_name: str = "file.txt",
         delimiter: str = "\t",
     ):


### PR DESCRIPTION
The `WriteToTextFileJob` wasn't having the format (generic csv) that I wanted, so I decided to write another job for that.

Note: there's a [`TextDictToTextLinesJob`](https://github.com/rwth-i6/i6_core/blob/main/text/convert.py#L12), but it doesn't seem to handle actual dictionaries but rather some RETURNN format.