### PR TITLE
A small fix for text read with uopen

### DIFF
--- a/lexicon/conversion.py
+++ b/lexicon/conversion.py
@@ -207,7 +207,7 @@ class LexiconFromTextFileJob(Job):
 
         phonemes = set()
         seen_lemma = {}
-        with uopen(self.text_file.get_path()) as f:
+        with uopen(self.text_file.get_path(), "rt") as f:
             for line in f:
                 # splitting is taken from RASR
                 # src/Tools/Bliss/blissLexiconLib.py#L185


### PR DESCRIPTION
Without explicitly setting mode to rt, the default mode for gzip.open is rb, which can't read gzipped text file correctly.