### PR TITLE
`Filter*ByAlignmentConfidenceJob`: better alignment plots

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -386,6 +386,26 @@ class FilterRecordingsByAlignmentConfidenceJob(FilterSegmentsByAlignmentConfiden
 
         return filtered_segments
 
+    def _plot(self, recording_dict: Dict[str, List[Tuple[str, float]]]):
+        """
+        Plots the average recording alignment scores.
+
+        :param recording_dict: Dictionary of recording full names to list of (segment full name, alignment score).
+        """
+        import matplotlib
+        import matplotlib.pyplot as plt
+
+        matplotlib.use("Agg")
+
+        score_np = self._get_alignment_scores_array(recording_dict)
+
+        # Before filtering.
+        plt.hist(score_np, bins=100)
+        plt.xlabel("Average Maximum-Likelihood Score")
+        plt.ylabel("Number of Recordings")
+        plt.title("Histogram of Alignment Scores")
+        plt.savefig(fname=self.out_plot_avg.get_path())
+
     def run(self):
         # Alignments that haven't reached a final state can bias the mean computation, so they're removed.
         recording_dict = self._parse_alignment_logs(self.alignment_logs, remove_dnf_alignments=True)

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -285,8 +285,7 @@ class FilterSegmentsByAlignmentConfidenceJob(Job):
         score_np = self._get_alignment_scores_array(recording_dict)
 
         # Before filtering.
-        np.clip(score_np, 0, 200, out=score_np)
-        plt.hist(score_np, bins=100, range=(0, 200))
+        plt.hist(score_np, bins=100)
         plt.xlabel("Average Maximum-Likelihood Score")
         plt.ylabel("Number of Segments")
         plt.title("Histogram of Alignment Scores")

--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -272,10 +272,9 @@ class FilterSegmentsByAlignmentConfidenceJob(Job):
 
     def _plot(self, recording_dict: Dict[str, List[Tuple[str, float]]]):
         """
-        Plots an alignment score.
+        Plots the individual segment alignment scores.
 
-        Note: the plot only takes into account strictly positive values.
-        For more customizable plotting, it's suggested to use :class:`i6_core.mm.alignment.PlotAlignmentJob` instead.
+        :param recording_dict: Dictionary of recording full names to list of (segment full name, alignment score).
         """
         import matplotlib
         import matplotlib.pyplot as plt


### PR DESCRIPTION
The alignment plots were previously useless when dealing with values outside of the disposed range, such as when aligning with NNs (negative alignment scores). Now the X axis range entirely depends on the distribution.

Also added a custom plot for the recording alignment scores, since the Y axis label was wrong (it said "segments" instead of "recordings").

Notes:
1. The previous plots would be irreproducible. However, for me this is not an issue due to the "cosmetic" nature of the change.
2. If the job is not triggered with `remove_dnf_alignments=True` (which is the recommended value anyway, and only set to `False` for retrocompatibility purposes), the graph might look bad (e.g. X axis extending from 0 to 1e+36, one big bar at [0, 200] and then nothing else). However, since I use NN-based alignments, it does already look bad to me for most of my filterings (just one histogram bar at 0 and then an empty graph), so I believe this would already be an improvement. To circumvent this, the user should set `remove_dnf_alignments=True`.
3. To fix (2), we can think of setting `remove_dnf_alignments=True` by default always. The alignments that did not finish aren't in the alignment caches anyway, so these being included here only pollutes the plot. What do you think?