### PR TITLE
make PtCheckpoint an os.PathLike

### DIFF
--- a/returnn/training.py
+++ b/returnn/training.py
@@ -99,6 +99,9 @@ class PtCheckpoint:
     def __repr__(self):
         return "'%s'" % self.path
 
+    def __fspath__(self):
+        return self.path.get()
+
     def exists(self):
         return os.path.exists(self.path.get_path())
 


### PR DESCRIPTION
Proper support for having it as `load` or in `preload_from_files` directly in RETURNN config files.