### PR TITLE
Recog v2 updates

### DIFF
--- a/rasr/config.py
+++ b/rasr/config.py
@@ -252,12 +252,9 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
     :return: config, post_config
     :rtype: (RasrConfig, RasrConfig)
     """
-    import pdb
-
     config = RasrConfig()
     post_config = RasrConfig()
 
-    pdb.set_trace()
     if include_log_config:
         config._update(crp.log_config)
         post_config._update(crp.log_post_config)

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -252,14 +252,17 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
     :return: config, post_config
     :rtype: (RasrConfig, RasrConfig)
     """
+    import pdb
+
     config = RasrConfig()
     post_config = RasrConfig()
 
+    pdb.set_trace()
     if include_log_config:
         config._update(crp.log_config)
         post_config._update(crp.log_post_config)
 
-    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model", "recognizer"]:
+    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model", "recognizer", "label_scorer"]:
         if mkey not in mapping:
             continue
         keys = mapping[mkey]

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -883,6 +883,7 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
         config, post_config = rasr.build_config_from_mapping(crp, mapping_dict)
 
         config.speech_recognizer.recognition_mode = "init-only"
+        config.speech_recognizer.search_type = search_type
         config.speech_recognizer.reocgnizer_type = recognizer_type
         config.speech_recognizer.global_cache.file = "global.cache"
         config.speech_recognizer.global_cache.read_only = False

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -818,9 +818,16 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
     Standalone job to create the global-cache for advanced-tree-search
     """
 
-    __sis_hash_exclude__ = {"search_type": "advanced-tree-search"}
+    __sis_hash_exclude__ = {"search_type": "advanced-tree-search", "recognizer_type": "recognizer"}
 
-    def __init__(self, crp, search_type="advanced-tree-search", extra_config=None, extra_post_config=None):
+    def __init__(
+        self,
+        crp,
+        search_type="advanced-tree-search",
+        recognizer_type="recognizer",
+        extra_config=None,
+        extra_post_config=None,
+    ):
         """
         :param rasr.CommonRasrParameters crp: common RASR params (required: lexicon, acoustic_model, language_model, recognizer)
         :param rasr.Configuration extra_config: overlay config that influences the Job's hash
@@ -859,19 +866,30 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
         util.backup_if_exists("build_global_cache.log")
 
     @classmethod
-    def create_config(cls, crp, search_type, extra_config, extra_post_config, **kwargs):
-        config, post_config = rasr.build_config_from_mapping(
-            crp,
-            {
-                "lexicon": "speech-recognizer.model-combination.lexicon",
-                "acoustic_model": "speech-recognizer.model-combination.acoustic-model",
-                "language_model": "speech-recognizer.model-combination.lm",
-                "recognizer": "speech-recognizer.recognizer",
-            },
-        )
+    def create_config(cls, crp, search_type, recognizer_type, extra_config, extra_post_config, **kwargs):
+        import pdb
+
+        pdb.set_trace()
+
+        mapping_dict = {
+            "lexicon": "speech-recognizer.model-combination.lexicon",
+            "acoustic_model": "speech-recognizer.model-combination.acoustic-model",
+            "language_model": "speech-recognizer.model-combination.lm",
+            "recognizer": "speech-recognizer.recognizer",
+            "label_scorer": "speech-recognizer.model-combination.label-scorer",
+        }
+
+        if recognizer_type == "recognizer-v2":
+            mapping_dict.update(
+                {
+                    "recognizer": "speech-recognizer.recognizer.search-algorithm",
+                }
+            )
+
+        config, post_config = rasr.build_config_from_mapping(crp, mapping_dict)
 
         config.speech_recognizer.recognition_mode = "init-only"
-        config.speech_recognizer.search_type = search_type
+        config.speech_recognizer.reocgnizer_type = recognizer_type
         config.speech_recognizer.global_cache.file = "global.cache"
         config.speech_recognizer.global_cache.read_only = False
 

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -873,13 +873,6 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
             "label_scorer": "speech-recognizer.model-combination.label-scorer",
         }
 
-        if recognizer_type == "recognizer-v2":
-            mapping_dict.update(
-                {
-                    "recognizer": "speech-recognizer.recognizer.search-algorithm",
-                }
-            )
-
         config, post_config = rasr.build_config_from_mapping(crp, mapping_dict)
 
         config.speech_recognizer.recognition_mode = "init-only"

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -7,6 +7,7 @@ __all__ = [
 ]
 
 from sisyphus import *
+import pdb
 
 Path = setup_path(__package__)
 
@@ -817,7 +818,9 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
     Standalone job to create the global-cache for advanced-tree-search
     """
 
-    def __init__(self, crp, extra_config=None, extra_post_config=None):
+    __sis_hash_exclude__ = {"search_type": "advanced-tree-search"}
+
+    def __init__(self, crp, search_type="advanced-tree-search", extra_config=None, extra_post_config=None):
         """
         :param rasr.CommonRasrParameters crp: common RASR params (required: lexicon, acoustic_model, language_model, recognizer)
         :param rasr.Configuration extra_config: overlay config that influences the Job's hash
@@ -832,6 +835,7 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
             self.config,
             self.post_config,
         ) = BuildGlobalCacheJob.create_config(**kwargs)
+        pdb.set_trace()
         self.exe = self.select_exe(crp.speech_recognizer_exe, "speech-recognizer")
 
         self.out_log_file = self.log_file_output_path("build_global_cache", crp, False)
@@ -855,7 +859,7 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
         util.backup_if_exists("build_global_cache.log")
 
     @classmethod
-    def create_config(cls, crp, extra_config, extra_post_config, **kwargs):
+    def create_config(cls, crp, search_type, extra_config, extra_post_config, **kwargs):
         config, post_config = rasr.build_config_from_mapping(
             crp,
             {
@@ -867,7 +871,7 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
         )
 
         config.speech_recognizer.recognition_mode = "init-only"
-        config.speech_recognizer.search_type = "advanced-tree-search"
+        config.speech_recognizer.search_type = search_type
         config.speech_recognizer.global_cache.file = "global.cache"
         config.speech_recognizer.global_cache.read_only = False
 

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -7,7 +7,6 @@ __all__ = [
 ]
 
 from sisyphus import *
-import pdb
 
 Path = setup_path(__package__)
 
@@ -842,7 +841,6 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
             self.config,
             self.post_config,
         ) = BuildGlobalCacheJob.create_config(**kwargs)
-        pdb.set_trace()
         self.exe = self.select_exe(crp.speech_recognizer_exe, "speech-recognizer")
 
         self.out_log_file = self.log_file_output_path("build_global_cache", crp, False)
@@ -867,10 +865,6 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
 
     @classmethod
     def create_config(cls, crp, search_type, recognizer_type, extra_config, extra_post_config, **kwargs):
-        import pdb
-
-        pdb.set_trace()
-
         mapping_dict = {
             "lexicon": "speech-recognizer.model-combination.lexicon",
             "acoustic_model": "speech-recognizer.model-combination.acoustic-model",


### PR DESCRIPTION
This is an update needed to run the new recognizer implemented by `SearchAlgorithmV2` in https://github.com/rwth-i6/rasr/blob/0e159e5ebe3ba12b712940fff6f18f8ce69bbe62/src/Search/SearchV2.hh#L52. 

For V2, `label-scorer` must be additionally set in RASR config (rasr/config.py). 
And `BuildGlobalCacheJob` must be expanded to handle search types other than `advanced-tree-search`. 