### PR TITLE
use binary mode to copy ungzipped file -- closes #618

### DIFF
--- a/text/processing.py
+++ b/text/processing.py
@@ -418,7 +418,7 @@ class SplitTextFileJob(Job):
             if self.in_text_file.get_path().endswith(".gz"):
                 logging.info("Un-compressing file")
                 text_file = f"{tmp_dir}/input_file.txt"
-                with open(text_file, "wt") as f_in:
+                with open(text_file, "wb") as f_in:
                     uncompress_cmd = ["gzip", "-cdk", self.in_text_file.get_path()]
                     subprocess.run(uncompress_cmd, check=True, stdout=f_in)
             else:


### PR DESCRIPTION
As outlined in the issue, this should be **probably surely** "wb", so that the write into the file is essentially "no-op" from python POV, i.e. no decoding and encoding should be done. It works well with "wt" if we assume "everyone uses utf-8 everywhere" but after we drop this assumption, it can yield incorrect behavior?

I'm not 100% certain, but it does look suspicious.