### PR TITLE
change hash func to only check concurrent in crp

### DIFF
--- a/corpus/filter.py
+++ b/corpus/filter.py
@@ -304,6 +304,16 @@ class FilterSegmentsByAlignmentConfidenceJob(Job):
         self._write_output_segment_files(filtered_segments)
         self._plot(recording_dict)
 
+    @classmethod
+    def hash(self, kwargs):
+        # only keep concurrent value from crp and ignore the rest
+        kwargs_copy = dict(**kwargs)
+        if kwargs["crp"] is not None:
+            concurrent = kwargs_copy["crp"].concurrent
+            del kwargs_copy["crp"]
+            kwargs_copy["concurrent"] = concurrent
+        return super().hash(kwargs_copy)
+
 
 class FilterRecordingsByAlignmentConfidenceJob(FilterSegmentsByAlignmentConfidenceJob):
     """


### PR DESCRIPTION
Change in the `CommonRasrParameters `, which will newly add `label_scorer_config` and `label_scorer_post_config`, can result in hash break by jobs that takes crp as argument. 

There are two jobs `FilterSegmentsByAlignmentConfidenceJob` and `FilterRecordingsByAlignmentConfidenceJob` that are affected by this, and this PR will update these job's hash func to only check on concurrent value which is the only one actually used. 