### PR TITLE
`get_executable_path`: remove accesses to `DelayedFormat.__str__` in the manager to comply with `DELAYED_CHECK_FOR_WORKER` sisyphus var, better logging

### DIFF
--- a/util.py
+++ b/util.py
@@ -336,7 +336,7 @@ def get_executable_path(
                 return path.args[0].join_right(path.args[1])
             else:
                 raise ValueError(
-                    f"get_executable_path: DelayedFormat provided {path} seems to be more complex than expected. "
+                    "get_executable_path: DelayedFormat provided seems to be more complex than expected. "
                     "Will not attempt to resolve it with path.get(), which might lead to side effects. "
                     "Consider concatenating `tk.Path.join_right(...).join_right(...)` in succession "
                     "or using a less complex path."


### PR DESCRIPTION
The main purpose of this PR is to remove all accesses to the sisyphus `Path` class in the manager. This is due to the fact that setting the sisyphus variable `DELAYED_CHECK_FOR_WORKER = True` makes the manager crash when printing `tk.Path` as a string, since it internally calls `get_cached_path()`.

Tangentially, the logging is improved by prefixing the function name in the warning (since this function is usually called many layers deep into the code).