### PR TITLE
remove mini task from AccumulateCartStatisticsJob

### DIFF
--- a/cart/estimate.py
+++ b/cart/estimate.py
@@ -73,7 +73,7 @@ class AccumulateCartStatisticsJob(rasr.RasrCommand, Job):
             rqmt=self.rqmt,
             args=range(1, self.concurrent + 1),
         )
-        yield Task("merge", mini_task=True)
+        yield Task("merge", mini_task=False)
 
     def create_files(self):
         self.write_config(self.config_accumulate, self.post_config_accumulate, "accumulate.config")


### PR DESCRIPTION
Having a mini-task conflicts with runtime environments.

The job then crashes because RASR searches for libraries that do not exist.