### PR TITLE
`ReturnnForwardJob[V2]`: accept `DelayedBase` as model

### DIFF
--- a/returnn/forward.py
+++ b/returnn/forward.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import List, Optional, Union, get_args
+from typing import List, Optional, Union
 
 from sisyphus import Job, Task, gs, setup_path, tk
 from sisyphus.delayed_ops import DelayedBase


### PR DESCRIPTION
Counter-PR to https://github.com/rwth-i6/i6_core/pull/628.

Thanks to @patrick-wilken, I was able to trigger `DelayedGetItem` on a dictionary and retrieve the delayed value itself. This seems to work wonderfully in most jobs as a `DelayedBase` variable, which most jobs support, except for `ReturnnForwardJob[V2]`. The base model receives it nicely, but there's an internal check that the model's absolute path should exist on disk.

This PR enables the check to also pass with `DelayedBase` objects, such as `DelayedGetItem`.

**One thing I'm wondering is: why would the job require a check that the path to the model exists? If it didn't exist, would the job simply not have been triggered?** Maybe we can remove the check altogether. What do you think?

---

PS: I also took the chance to improve the `parameter_tuning.py` file by adding an `__all__` list and reordering the imports for clarity (python, third party, specific to `i6_core`). If you don't like this or feel it's too off-topic, please let me know and I'll abandon these changes.