### PR TITLE
Also instanciate params

### DIFF
--- a/tools/parameter_tuning.py
+++ b/tools/parameter_tuning.py
@@ -47,6 +47,7 @@ class GetOptimalParametersAsVariableJob(Job):
         yield Task("run", mini_task=True)
 
     def run(self):
+        self.parameters = instanciate_delayed(self.parameters)
         values = instanciate_delayed(self.values)
 
         if self.mode == "minimize":


### PR DESCRIPTION
I ran into the issue that the params of this job would also be sis variables (In this case actually outputs of this job) and later in the config serialization they would not properly be recognized as variables of type float but as variables of type variable instead. This should fix the issue.