### PR TITLE
Update CommonRasrParameters and build_config_from_mapping to support multiple label scorers

### DIFF
--- a/rasr/config.py
+++ b/rasr/config.py
@@ -269,9 +269,9 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
             if mkey == "label_scorers":
                 label_scorer_configs = getattr(crp, mkey)
                 num_label_scorers = len(label_scorer_configs)
-                label_scorer_top_level_key = key.split(".")[:len(key.split("."))-1]
+                label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
                 config[".".join(label_scorer_top_level_key + ["num-scorers"])] = num_label_scorers
-                
+
                 for i, (c, pc) in enumerate(label_scorer_configs, start=1):
                     if c is not None:
                         config[f"{key}-{i}"] = c
@@ -281,7 +281,7 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
                 c = getattr(crp, "%s_config" % mkey)
                 if c is not None:
                     config[key] = c
-    
+
                 c = getattr(crp, "%s_post_config" % mkey)
                 if c is not None:
                     post_config[key] = c

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -267,16 +267,19 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
             keys = (keys,)
         for key in keys:
             if mkey == "label_scorers":
-                label_scorer_configs = getattr(crp, mkey)
-                num_label_scorers = len(label_scorer_configs)
-                label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
-                config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
-
-                for i, (c, pc) in enumerate(label_scorer_configs, start=1):
-                    if c is not None:
-                        config[f"{key}-{i}"] = c
-                    if pc is not None:
-                        post_config[f"{key}-{i}"] = pc
+                # ONLY continue when crp contains label_scorers
+                # most cases (recognizer-v1), crp does not have any label_scorers
+                label_scorer_configs = getattr(crp, mkey, None)
+                if label_scorer_configs is not None:
+                    num_label_scorers = len(label_scorer_configs)
+                    label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
+                    config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
+    
+                    for i, (c, pc) in enumerate(label_scorer_configs, start=1):
+                        if c is not None:
+                            config[f"{key}-{i}"] = c
+                        if pc is not None:
+                            post_config[f"{key}-{i}"] = pc
             else:
                 c = getattr(crp, "%s_config" % mkey)
                 if c is not None:

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -267,12 +267,21 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
             keys = (keys,)
         for key in keys:
             if mkey == "label_scorers":
-                label_scorer_configs = getattr(crp, mkey, None)
+                label_scorer_configs = getattr(crp, mkey)
                 num_label_scorers = len(label_scorer_configs)
-                if num_label_scorers > 0:
-                    label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
-                    config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
-    
+                if num_label_scorers == 0:
+                    continue
+
+                label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
+                config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
+
+                if num_label_scorers == 1:
+                    c, pc = label_scorer_configs[0]
+                    if c is not None:
+                        config[key] = c
+                    if pc is not None:
+                        post_config[key] = pc
+                else:
                     for i, (c, pc) in enumerate(label_scorer_configs, start=1):
                         if c is not None:
                             config[f"{key}-{i}"] = c

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -267,13 +267,8 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
             keys = (keys,)
         for key in keys:
             if mkey == "label_scorers":
-                label_scorer_configs = getattr(crp, mkey)
+                label_scorer_configs = crp.label_scorers
                 num_label_scorers = len(label_scorer_configs)
-                if num_label_scorers == 0:
-                    continue
-
-                label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
-                config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
 
                 if num_label_scorers == 1:
                     c, pc = label_scorer_configs[0]
@@ -281,7 +276,9 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
                         config[key] = c
                     if pc is not None:
                         post_config[key] = pc
-                else:
+                elif num_label_scorers > 1:
+                    label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
+                    config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
                     for i, (c, pc) in enumerate(label_scorer_configs, start=1):
                         if c is not None:
                             config[f"{key}-{i}"] = c

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -259,34 +259,32 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         config._update(crp.log_config)
         post_config._update(crp.log_post_config)
 
-    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model", "recognizer", "label_scorer"]:
+    for mkey in ["corpus", "lexicon", "acoustic_model", "language_model", "recognizer", "label_scorers"]:
         if mkey not in mapping:
             continue
         keys = mapping[mkey]
         if type(keys) == str:
             keys = (keys,)
         for key in keys:
-            num_config = 1
-            if mkey == "label_scorer":
-                num_label_scorers = crp.num_label_scorers
-                config.speech_recognizer.model_combination.num_label_scorers = num_label_scorers
-                num_config = num_label_scorers
-
-            if num_config == 1:
+            if mkey == "label_scorers":
+                label_scorer_configs = getattr(crp, mkey)
+                num_label_scorers = len(label_scorer_configs)
+                label_scorer_top_level_key = key.split(".")[:len(key.split("."))-1]
+                config[".".join(label_scorer_top_level_key + ["num-scorers"])] = num_label_scorers
+                
+                for i, (c, pc) in enumerate(label_scorer_configs, start=1):
+                    if c is not None:
+                        config[f"{key}-{i}"] = c
+                    if pc is not None:
+                        post_config[f"{key}-{i}"] = pc
+            else:
                 c = getattr(crp, "%s_config" % mkey)
                 if c is not None:
                     config[key] = c
+    
                 c = getattr(crp, "%s_post_config" % mkey)
                 if c is not None:
                     post_config[key] = c
-            else:
-                for i in range(num_label_scorers):
-                    c = getattr(crp, f"{mkey}_{i + 1}_config")
-                    if c is not None:
-                        config[f"{key}-{i + 1}"] = c
-                    c = getattr(crp, f"{mkey}_{i + 1}_post_config")
-                    if c is not None:
-                        post_config[f"{key}-{i + 1}"] = c
 
             if mkey == "corpus" and parallelize:
                 if crp.segment_path is not None:

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -267,8 +267,6 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
             keys = (keys,)
         for key in keys:
             if mkey == "label_scorers":
-                # ONLY continue when crp contains label_scorers
-                # most cases (recognizer-v1), crp does not have any label_scorers
                 label_scorer_configs = getattr(crp, mkey, None)
                 if label_scorer_configs is not None:
                     num_label_scorers = len(label_scorer_configs)

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -268,9 +268,7 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         for key in keys:
             num_config = 1
             if mkey == "label_scorer":
-                print(crp)
                 num_label_scorers = getattr(crp, "num_label_scorers")
-                print(f"num_label_scorers: {num_label_scorers}")
                 config.speech_recognizer.model_combination.num_label_scorers = num_label_scorers
                 num_config = num_label_scorers
 

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -281,12 +281,12 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
                     post_config[key] = c
             else:
                 for i in range(num_label_scorers):
-                    c = getattr(crp, f"{mkey}_{i+1}_config")
+                    c = getattr(crp, f"{mkey}_{i + 1}_config")
                     if c is not None:
-                        config[f"{key}-{i+1}"] = c
-                    c = getattr(crp, f"{mkey}_{i+1}_post_config")
+                        config[f"{key}-{i + 1}"] = c
+                    c = getattr(crp, f"{mkey}_{i + 1}_post_config")
                     if c is not None:
-                        post_config[f"{key}-{i+1}"] = c
+                        post_config[f"{key}-{i + 1}"] = c
 
             if mkey == "corpus" and parallelize:
                 if crp.segment_path is not None:

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -270,7 +270,7 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
                 label_scorer_configs = getattr(crp, mkey)
                 num_label_scorers = len(label_scorer_configs)
                 label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
-                config[".".join(label_scorer_top_level_key + ["num-scorers"])] = num_label_scorers
+                config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
 
                 for i, (c, pc) in enumerate(label_scorer_configs, start=1):
                     if c is not None:

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -268,8 +268,8 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         for key in keys:
             if mkey == "label_scorers":
                 label_scorer_configs = getattr(crp, mkey, None)
-                if label_scorer_configs is not None:
-                    num_label_scorers = len(label_scorer_configs)
+                num_label_scorers = len(label_scorer_configs)
+                if num_label_scorers > 0:
                     label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
                     config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
     

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -266,13 +266,29 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         if type(keys) == str:
             keys = (keys,)
         for key in keys:
-            c = getattr(crp, "%s_config" % mkey)
-            if c is not None:
-                config[key] = c
+            num_config = 1
+            if mkey == "label_scorer":
+                print(crp)
+                num_label_scorers = getattr(crp, "num_label_scorers")
+                print(f"num_label_scorers: {num_label_scorers}")
+                config.speech_recognizer.model_combination.num_label_scorers = num_label_scorers
+                num_config = num_label_scorers
 
-            c = getattr(crp, "%s_post_config" % mkey)
-            if c is not None:
-                post_config[key] = c
+            if num_config == 1:
+                c = getattr(crp, "%s_config" % mkey)
+                if c is not None:
+                    config[key] = c
+                c = getattr(crp, "%s_post_config" % mkey)
+                if c is not None:
+                    post_config[key] = c
+            else:
+                for i in range(num_label_scorers):
+                    c = getattr(crp, f"{mkey}_{i+1}_config")
+                    if c is not None:
+                        config[f"{key}-{i+1}"] = c
+                    c = getattr(crp, f"{mkey}_{i+1}_post_config")
+                    if c is not None:
+                        post_config[f"{key}-{i+1}"] = c
 
             if mkey == "corpus" and parallelize:
                 if crp.segment_path is not None:

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -268,7 +268,7 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
         for key in keys:
             num_config = 1
             if mkey == "label_scorer":
-                num_label_scorers = getattr(crp, "num_label_scorers")
+                num_label_scorers = crp.num_label_scorers
                 config.speech_recognizer.model_combination.num_label_scorers = num_label_scorers
                 num_config = num_label_scorers
 

--- a/rasr/config.py
+++ b/rasr/config.py
@@ -277,8 +277,8 @@ def build_config_from_mapping(crp, mapping, include_log_config=True, parallelize
                     if pc is not None:
                         post_config[key] = pc
                 elif num_label_scorers > 1:
-                    label_scorer_top_level_key = key.split(".")[: len(key.split(".")) - 1]
-                    config[".".join(label_scorer_top_level_key + ["num-label-scorers"])] = num_label_scorers
+                    label_scorer_top_level_key = key.rsplit(".", maxsplit=1)[0]
+                    config[label_scorer_top_level_key + ".num-label-scorers"] = num_label_scorers
                     for i, (c, pc) in enumerate(label_scorer_configs, start=1):
                         if c is not None:
                             config[f"{key}-{i}"] = c

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -26,7 +26,7 @@ class CommonRasrParameters:
             self.language_model_post_config = None
             self.recognizer_config = None
             self.recognizer_post_config = None
-            self.label_scorer_config = None
+            self.label_scorers = None
             self.label_scorer_post_config = None
 
             self.log_config = None

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -4,6 +4,8 @@ from sisyphus import tk
 from .command import RasrCommand
 from .config import RasrConfig
 
+from typing import List, Tuple
+
 
 class CommonRasrParameters:
     """
@@ -26,7 +28,7 @@ class CommonRasrParameters:
             self.language_model_post_config = None
             self.recognizer_config = None
             self.recognizer_post_config = None
-            self.label_scorers = []
+            self.label_scorers: list[tuple[RasrConfig, RasrConfig]] = []
 
             self.log_config = None
             self.log_post_config = None

--- a/rasr/crp.py
+++ b/rasr/crp.py
@@ -26,8 +26,7 @@ class CommonRasrParameters:
             self.language_model_post_config = None
             self.recognizer_config = None
             self.recognizer_post_config = None
-            self.label_scorers = None
-            self.label_scorer_post_config = None
+            self.label_scorers = []
 
             self.log_config = None
             self.log_post_config = None

--- a/recognition/advanced_tree_search.py
+++ b/recognition/advanced_tree_search.py
@@ -912,7 +912,7 @@ class BuildGlobalCacheJob(rasr.RasrCommand, Job):
         }
 
         if search_algorithm_interface_type == "search-v2":
-            mapping_dict["label_scorer"] = "speech-recognizer.model-combination.label-scorer"
+            mapping_dict["label_scorers"] = "speech-recognizer.model-combination.label-scorer"
 
         config, post_config = rasr.build_config_from_mapping(crp, mapping_dict)
 


### PR DESCRIPTION
In SearchAlgorithmV2, each label scorer config must be set under individual block `model-combination.label-scorer-{i}`. 