### PR TITLE
TransformAndMapHuggingFaceDatasetJob and ExtractTextFromHuggingFaceDatasetJob: support nodes without internet access.

### DIFF
--- a/datasets/huggingface.py
+++ b/datasets/huggingface.py
@@ -15,6 +15,27 @@ if TYPE_CHECKING:
     TransformFuncT = Union[Callable[[DatasetDict], DatasetDict], Callable[[Dataset], Dataset]]
 
 
+def load_hf_dataset(path, **opts):
+    """
+    If `HF_HUB_OFFLINE` is set to true, only use the local files in `HF_HOME` to load the dataset.
+    Otherwise, `load_dataset` tries to load metadata from the internet.
+
+    This can be used for nodes which don't have internet access (e.g. JUPITER in Jülich).
+    """
+    import os
+    from datasets import load_dataset
+    from huggingface_hub import snapshot_download
+
+    if os.environ.get("HF_HUB_OFFLINE") == "1":
+        path = snapshot_download(
+            repo_id=path,
+            repo_type="dataset",
+            local_files_only=True,
+        )
+
+    return load_dataset(path, **opts)
+
+
 class DownloadAndPrepareHuggingFaceDatasetJob(Job):
     """
     https://huggingface.co/docs/datasets/
@@ -242,7 +263,7 @@ class TransformAndMapHuggingFaceDatasetJob(Job):
                 " or via job.set_env"
             )
 
-            ds = load_dataset(dataset_path, **load_dataset_opts)
+            ds = load_hf_dataset(dataset_path, **load_dataset_opts)
             assert isinstance(ds, (Dataset, DatasetDict))
 
         if self.transform:
@@ -342,7 +363,7 @@ class ExtractTextFromHuggingFaceDatasetJob(Job):
         import time
         from datasets import load_dataset, Dataset
 
-        ds = load_dataset(self.path, self.name, split=self.split)
+        ds = load_hf_dataset(self.path, name=self.name, split=self.split)
         assert isinstance(ds, Dataset), f"Expected a Dataset, got {type(ds)} {ds}"
         assert self.column_name in ds.column_names, f"Column name {self.column_name} not in columns {ds.column_names}"
 

--- a/datasets/huggingface.py
+++ b/datasets/huggingface.py
@@ -26,7 +26,7 @@ def load_hf_dataset(path, **opts):
     from datasets import load_dataset
     from huggingface_hub import snapshot_download
 
-    if os.environ.get("HF_HUB_OFFLINE") == "1":
+    if is_offline_mode():
         path = snapshot_download(
             repo_id=path,
             repo_type="dataset",

--- a/datasets/huggingface.py
+++ b/datasets/huggingface.py
@@ -24,9 +24,11 @@ def load_hf_dataset(path, **opts):
     """
     import os
     from datasets import load_dataset
-    from huggingface_hub import snapshot_download
+    from huggingface_hub import snapshot_download, is_offline_mode
 
     if is_offline_mode():
+        # `snapshot_download` just locates the dataset files, if they already exist on disk
+        # `load_dataset` does more, including a check for metadata online, which would not work without internet access
         path = snapshot_download(
             repo_id=path,
             repo_type="dataset",


### PR DESCRIPTION
These jobs fail if there is no internet access, even if the required data is present in `HF_HOME`. This fixes this by using `snapshot_download` first with the `local_files_only=True` option.