### PR TITLE
LibriSpeechCreateBlissCorpusJob: use add_recording/add_segment

### DIFF
--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -149,8 +149,8 @@ class LibriSpeechCreateBlissCorpusJob(Job):
             segment.end = float("inf")
             segment.orth = transcript["orth"].strip()
 
-            recording.segments.append(segment)
-            c.recordings.append(recording)
+            recording.add_segment(segment)
+            c.add_recording(recording)
 
         for speaker_id, speaker_info in sorted(self._speakers.items()):
             if speaker_id not in used_speaker_ids:


### PR DESCRIPTION
Add recordings and segments via `add_recording`/`add_segment` instead of appending to the lists directly, so the `recording.corpus` and `segment.recording` backreferences get set. The dumped corpus is identical, this only keeps the in-memory objects consistent so `fullname()` and `speaker()` work on the freshly built corpus.