### PR TITLE
 ExtractTextFromHuggingFaceDatasetJob: add revision arg

### DIFF
--- a/datasets/huggingface.py
+++ b/datasets/huggingface.py
@@ -348,22 +348,32 @@ class ExtractTextFromHuggingFaceDatasetJob(Job):
         *,
         split: Optional[str] = "train",
         column_name: str = "text",
+        revision: Optional[str] = None,
     ):
         """
         :param path: for :func:`datasets.load_dataset`
         :param name: for :func:`datasets.load_dataset`
         :param split: for :func:`datasets.load_dataset`
         :param column_name: name of the text column to extract
+        :param revision: dataset version (git revision) of the dataset
         """
         super().__init__()
         self.path = path
         self.name = name
         self.split = split
         self.column_name = column_name
+        self.revision = revision
 
         self.rqmt = {"cpu": 4, "mem": 8, "time": 10}
 
         self.out_text = self.output_path("text.txt.gz")
+
+    @classmethod
+    def hash(cls, kwargs):
+        # keep the hash stable for callers that do not pin a revision
+        if kwargs.get("revision") is None:
+            kwargs = {k: v for k, v in kwargs.items() if k != "revision"}
+        return super().hash(kwargs)
 
     def tasks(self):
         yield Task("run", resume="run", rqmt=self.rqmt)
@@ -374,7 +384,7 @@ class ExtractTextFromHuggingFaceDatasetJob(Job):
         import time
         from datasets import load_dataset, Dataset
 
-        ds = load_hf_dataset(self.path, name=self.name, split=self.split)
+        ds = load_hf_dataset(self.path, name=self.name, split=self.split, revision=self.revision)
         assert isinstance(ds, Dataset), f"Expected a Dataset, got {type(ds)} {ds}"
         assert self.column_name in ds.column_names, f"Column name {self.column_name} not in columns {ds.column_names}"
 

--- a/datasets/huggingface.py
+++ b/datasets/huggingface.py
@@ -341,6 +341,8 @@ class ExtractTextFromHuggingFaceDatasetJob(Job):
     Extract a text column from a HF dataset and write it to a gzipped text file.
     """
 
+    __sis_hash_exclude__ = {"revision": None}
+
     def __init__(
         self,
         path: Union[str, Path],
@@ -367,13 +369,6 @@ class ExtractTextFromHuggingFaceDatasetJob(Job):
         self.rqmt = {"cpu": 4, "mem": 8, "time": 10}
 
         self.out_text = self.output_path("text.txt.gz")
-
-    @classmethod
-    def hash(cls, kwargs):
-        # keep the hash stable for callers that do not pin a revision
-        if kwargs.get("revision") is None:
-            kwargs = {k: v for k, v in kwargs.items() if k != "revision"}
-        return super().hash(kwargs)
 
     def tasks(self):
         yield Task("run", resume="run", rqmt=self.rqmt)


### PR DESCRIPTION
Add an optional revision argument to `ExtractTextFromHuggingFaceDatasetJob`, forwarded to `load_hf_dataset`/`load_dataset`, so callers can pin a specific dataset commit instead of resolving the moving default branch.

The job hash stays stable for callers that do not set revision (the `hash` classmethod drops it when `None`), mirroring the per-argument hash handling in `TransformAndMapHuggingFaceDatasetJob`.